### PR TITLE
UpdateChecker: use correct DNS target on ARM desktops

### DIFF
--- a/src/monerodui/libs/update_checker.py
+++ b/src/monerodui/libs/update_checker.py
@@ -80,6 +80,13 @@ class UpdateChecker:
                 return "monero:android-armv8:"
             else:
                 return "monero:android-armv7:"
+        # Desktop — pick TXT-record platform string by detected arch.
+        # Falls back to linux-x64 for unrecognized arches (matches the
+        # pre-fix behavior, so x86_64 boxes are unaffected).
+        if self._arch == "arm64":
+            return "monero:linux-armv8:"
+        if self._arch == "arm32":
+            return "monero:linux-armv7:"
         return "monero:linux-x64:"
 
     def _fetch_remote_version(self) -> Optional[Tuple[str, str]]:


### PR DESCRIPTION
`UpdateChecker._get_dns_target()` hardcodes `monero:linux-x64:` on the desktop branch, ignoring `self._arch`. On a Pi or any non-x86 Linux box the update check returns the x86_64 version + hash, and a sha256sum verify against the actual ARM tarball the user downloaded will fail.

This pull request fixes the issue.   It's just 7 lines, so hopefully it's easy to vet.