### PR TITLE
Add a NiceGUI web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+.eggs/
+pip-wheel-metadata/
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Testing
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+.tox/
+.nox/
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Briefcase / Briefcase build artifacts
+android/build/
+android/.gradle/
+android/.briefcase/
+
+# Buildozer
+.buildozer/
+bin/
+
+# OS
+Thumbs.db
+
+# Local config / secrets (project-specific, if any)
+.env
+.env.local

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -5,7 +5,7 @@ package.domain = org.monerodui
 source.dir = src
 source.include_exts = py,png,jpg,kv,atlas,json,svg,ini,whl,so,java
 source.include_patterns = assets/*,screens/**/*.py,services/*.py,utils/*,ui/**/*.kv,monerodui/service.py
-source.exclude_dirs = data,.buildozer,tests,.venv,venv,__pycache__
+source.exclude_dirs = data,.buildozer,tests,.venv,venv,__pycache__,monerodui_web
 version = 0.1.0
 
 requirements = python3,kivy,https://github.com/kivymd/KivyMD/archive/master.zip,pillow,materialyoucolor,asynckivy,asyncgui,Kivy-Garden,android,setuptools,wheel,plyer,monerod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,37 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "monerodui"
+version = "0.1.0"
+description = "monerod UI — Kivy desktop app and NiceGUI web companion for managing a monerod node."
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+authors = [
+    { name = "Terry A. Davis", email = "terry@monerodui.org" },
+]
+# Kivy desktop deps live under [tool.briefcase.app.monerodui.requires];
+# the [project] table here is intentionally lean so `pip install
+# .[web]` can install the web UI without dragging Kivy in.
+dependencies = []
+
+[project.optional-dependencies]
+web = [
+    "nicegui>=2.0.0",
+]
+
+[project.scripts]
+monerodui-web = "monerodui_web.main:main"
+
+[project.urls]
+Homepage = "https://monerod.org/monerodui"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["monerodui*", "monerodui_web*"]
+
 [tool.briefcase]
 project_name = "monerod UI"
 bundle = "org.monerodui"

--- a/src/monerodui/libs/update_checker.py
+++ b/src/monerodui/libs/update_checker.py
@@ -80,6 +80,13 @@ class UpdateChecker:
                 return "monero:android-armv8:"
             else:
                 return "monero:android-armv7:"
+        # Desktop — pick TXT-record platform string by detected arch.
+        # Falls back to linux-x64 for unrecognized arches (matches the
+        # pre-fix behavior, so x86_64 boxes are unaffected).
+        if self._arch == "arm64":
+            return "monero:linux-armv8:"
+        if self._arch == "arm32":
+            return "monero:linux-armv7:"
         return "monero:linux-x64:"
 
     def _fetch_remote_version(self) -> Optional[Tuple[str, str]]:

--- a/src/monerodui_web/README.md
+++ b/src/monerodui_web/README.md
@@ -13,7 +13,7 @@ If you already have the Kivy app installed and configured, the web UI picks up i
 
 ## Requirements
 
-- Linux (Ubuntu 22.04+ / similar). The Kivy app's Android target is out of scope here.
+- **Linux** (Ubuntu 22.04+ or similar). Android is not a target for this package — the parent Kivy app at `src/monerodui/` is what gets bundled into the APK; `monerodui_web/` is in `source.exclude_dirs` in `buildozer.spec`.
 - Python 3.10+.
 - monerod binary somewhere on the system (see [Binary discovery](#binary-discovery) below).
 - A browser. No special version needed — anything from the last few years works.
@@ -63,7 +63,7 @@ src/monerodui_web/
 ├── main.py                # NiceGUI entrypoint: ui.run(), startup hooks,
 │                          # /api/status JSON endpoint, route registration
 ├── core/
-│   ├── __init__.py        # Re-exports state, config, ScreenedMonerod
+│   ├── __init__.py        # Re-exports the `state` and `config` singletons
 │   ├── app_state.py       # Single shared AppState dataclass (the
 │   │                      # source of truth for everything the UI shows)
 │   ├── config_manager.py  # ConfigManager: wraps configparser, port of
@@ -157,7 +157,9 @@ Returns a single snapshot at request time. The server's polling loop refreshes t
   "update_status": {
     "update_available": true,
     "local_version": "0.18.4.5",
-    "remote_version": "0.18.5.0"
+    "remote_version": "0.18.5.0",
+    "remote_hash": "423b49f3658e29f70a1d971667dec924c7ee7a107cfc93440456e28500b471a6",
+    "download_url": "https://downloads.getmonero.org/cli/monero-linux-x64-v0.18.5.0.tar.bz2"
   },
   "node_stats": {
     "nettype": "mainnet",
@@ -206,7 +208,7 @@ Returns a single snapshot at request time. The server's polling loop refreshes t
 
 ### Field notes
 
-- **`update_status`** is `null` until the startup version+update check completes (a few seconds after server start). If you're up-to-date, `update_available` is `false` and the banner is hidden in the UI.
+- **`update_status`** is `null` until the startup version+update check completes (a few seconds after server start). If you're up-to-date, `update_available` is `false` and the banner is hidden in the UI. `download_url` is `null` for unrecognized arches (only `amd64` / `arm64` / `arm32` desktop builds are mapped).
 - **`node_stats`** is `null` until the first successful poll lands (1 second after the first page load). If the poll fails (daemon offline, RPC unreachable), `node_stats` stays at its last good value and `polling.last_poll_error` carries the error string.
 - **`restricted_rpc: true`** indicates monerod is running with `--restricted-rpc`. When true, these fields are **redacted to 0 by monerod itself**, not actually zero:
   - `node_stats.overview.connections_*`
@@ -226,8 +228,6 @@ while true; do
   sleep 30
 done
 ```
-
-(That uses pipes — write it as a script, not a one-liner under the Claude Code Bash hook.)
 
 ## Development
 
@@ -263,7 +263,6 @@ There aren't any (yet). The end-to-end "test" is launch + browse. Settings parit
 - **`--restricted-rpc` redactions show as `*` in the UI** with an always-visible footnote explaining why. See the JSON API section above for the full list of affected fields.
 - **The version banner uses Monero's full release name** (`'Fluorine Fermi' (v0.18.4.5-release)`), not the short form (`v0.18.4.5`). Matches what the Kivy app shows.
 - **Status card collapse is a UI-only toggle**, not persisted to config. Reopening the page resets it to expanded.
-- **`ss -tlnp sport = :PORT`** triggers Claude Code's permission-prompt "parse error" path. If you script around the web UI from inside a Claude session, prefer `lsof -iTCP:PORT -sTCP:LISTEN`.
 
 ## Related files
 

--- a/src/monerodui_web/README.md
+++ b/src/monerodui_web/README.md
@@ -262,7 +262,7 @@ There aren't any (yet). The end-to-end "test" is launch + browse. Settings parit
 
 - **`--restricted-rpc` redactions show as `*` in the UI** with an always-visible footnote explaining why. See the JSON API section above for the full list of affected fields.
 - **The version banner uses Monero's full release name** (`'Fluorine Fermi' (v0.18.4.5-release)`), not the short form (`v0.18.4.5`). Matches what the Kivy app shows.
-- **Status card collapse is a UI-only toggle**, not persisted to config. Reopening the page resets it to expanded.
+- **Status card collapse** is a server-side toggle: it survives page reloads and new tabs (all tabs see the same state) but resets to expanded on `service monerodui-web restart`. Not persisted to disk.
 
 ## Related files
 

--- a/src/monerodui_web/README.md
+++ b/src/monerodui_web/README.md
@@ -1,0 +1,271 @@
+# monerod UI — Web
+
+A browser-accessible port of the [monerod UI](../../README.md) Kivy desktop app, built on **[NiceGUI](https://nicegui.io/)** 3.x (FastAPI + Quasar/Vue under the hood). The Kivy app keeps working unchanged; this is a parallel package that shares the same configuration, the same monerod-management library code, and the same on-disk INI file — only the UI layer is reimplemented.
+
+If you already have the Kivy app installed and configured, the web UI picks up its settings automatically.
+
+## Why a web UI?
+
+- **Remote access**: control monerod from any device on your LAN — phones, tablets, other laptops, anything with a browser. The Kivy app only works on the machine running it.
+- **No display required**: runs headless on a server or VPS. No X11, no Wayland, no GPU.
+- **Same UX language**: dark theme, orange accents, same five status rows and stats grid as the Kivy desktop app. The layout is a 1:1 port, not a redesign.
+- **Coexists with the desktop app**: both packages live under `src/`; both read and write the same `~/.config/monerodui/monerodui.ini`. Run whichever is convenient — just don't run both at the same time against the same daemon.
+
+## Requirements
+
+- Linux (Ubuntu 22.04+ / similar). The Kivy app's Android target is out of scope here.
+- Python 3.10+.
+- monerod binary somewhere on the system (see [Binary discovery](#binary-discovery) below).
+- A browser. No special version needed — anything from the last few years works.
+
+## Quick start
+
+```bash
+cd /path/to/monerodui
+
+# One-time setup: create a venv and install with the [web] extra
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[web]"
+
+# Run
+monerodui-web
+```
+
+Open `http://127.0.0.1:8085` in a browser. That's it.
+
+To stop the server: `Ctrl-C` in the terminal, or `kill <pid>`.
+
+## Network access
+
+By default the server binds to `0.0.0.0:8085`, meaning **anything on your LAN can reach it** (subject to your router/firewall). There is **no authentication** in v1 — anyone who can reach the URL can start/stop monerod and change its config.
+
+That's safe if:
+- Your LAN is trusted (your own devices only), AND
+- Your router doesn't port-forward 8085 to the internet.
+
+If either of those changes, put the UI behind a reverse proxy with auth (nginx basic auth, Caddy with basicauth, Tailscale, etc.) before exposing it further.
+
+To restrict to localhost only, edit the `WEB_HOST` constant near the top of `main.py`:
+
+```python
+WEB_HOST: str = "127.0.0.1"   # was "0.0.0.0"
+```
+
+To change the port, edit `WEB_PORT` in the same block.
+
+## Architecture
+
+```
+src/monerodui_web/
+├── __init__.py            # Package marker
+├── __main__.py            # Enables `python -m monerodui_web`
+├── main.py                # NiceGUI entrypoint: ui.run(), startup hooks,
+│                          # /api/status JSON endpoint, route registration
+├── core/
+│   ├── __init__.py        # Re-exports state, config, ScreenedMonerod
+│   ├── app_state.py       # Single shared AppState dataclass (the
+│   │                      # source of truth for everything the UI shows)
+│   ├── config_manager.py  # ConfigManager: wraps configparser, port of
+│   │                      # the Kivy _get_extra_args() (~270 lines that
+│   │                      # translate INI → monerod CLI args)
+│   └── process_adapter.py # discover_external_monerod_pid() helper
+├── pages/
+│   ├── __init__.py        # Re-exports build_dashboard, build_settings_page
+│   ├── dashboard.py       # `/` route — status card + stats card +
+│   │                      # Start/Stop button + polling loop
+│   └── settings.py        # `/settings` route — 82-field settings form
+│                          # mirroring the Kivy settings panel
+└── components/
+    ├── __init__.py
+    ├── status_card.py     # Architecture / IP / Binary / Storage / State
+    │                      # (collapsible)
+    └── node_stats_card.py # Version + update banners, sync progress,
+                           # OVERVIEW / NETWORK / BLOCKCHAIN / RESOURCES
+```
+
+### Shared with the Kivy app (read-only — never modify from here)
+
+The web UI imports several modules from the Kivy package as pure libraries. None of these have Kivy dependencies:
+
+- `monerodui.libs.arch_detector` — CPU architecture detection
+- `monerodui.libs.process_manager` — monerod subprocess lifecycle
+- `monerodui.libs.node_stats` — RPC poll → `NodeStats` dataclass
+- `monerodui.libs.version_checker` — extracts version from `monerod --version`
+- `monerodui.libs.update_checker` — checks DNS TXT for newer releases
+- `monerodui.libs.network_info` — device IP detection
+- `monerodui.settings.settings_schema.json` — source of truth for the 82 settings fields
+
+### Why these design choices
+
+- **Polling, not websockets, for node stats.** Every browser tab runs a `ui.timer(10s)` that hits monerod's RPC, stores the result in the shared `AppState`, and refreshes the `@ui.refreshable` components. Simpler than push, and 10s granularity matches what humans care about for blockchain stats.
+- **One shared `AppState` singleton.** All pages and refreshable components read from `state` (`monerodui_web/core/app_state.py`). Background tasks write to it. No observers, no event bus — just plain attribute assignment plus `.refresh()` calls.
+- **ProcessManager runs monerod directly, no `screen` wrapper.** The Kivy `ProcessManager` auto-appends `--log-file <data_dir>/monerod.log`, which gives the same observability as `screen -r monerod` (just `tail -f /root/.bitmonero/monerod.log`).
+- **External-daemon detection.** If you're already running monerod outside the UI (e.g. in `screen`), the dashboard detects it via `pgrep -x monerod` plus an RPC poll, surfaces it as "Running (external)", and disables the Stop button (the UI never kills a process it didn't spawn).
+
+## Configuration
+
+The web UI shares **`~/.config/monerodui/monerodui.ini`** with the Kivy app. No conversion, no migration — the same file works for both.
+
+If the file doesn't exist on first run, defaults are written. The web UI also backfills `advanced.data_dir = ~/.bitmonero` if empty, matching Monero's own default.
+
+Settings can be edited two ways:
+1. The web UI's **Settings** page (gear icon, top right) — full form for all 82 fields across 17 INI sections.
+2. Hand-editing the INI file — useful for bulk changes or scripted setup.
+
+Changes take effect on **next monerod restart**, not live (matches Kivy behavior).
+
+### Binary discovery
+
+The web UI looks for `monerod` in this order:
+
+1. **`/root/monero/monerod`** (`PREFERRED_BINARY` in `main.py`). On the apollo dev machine this is a symlink the user maintains pointing at the current Monero release.
+2. The Kivy `ArchDetector` search path (Briefcase-layout `desktop/binary/`, project root, app root).
+3. `shutil.which('monerod')` — anything on `PATH`.
+
+Edit `PREFERRED_BINARY` in `main.py` if your preferred location is different.
+
+## JSON API: `/api/status`
+
+Every field on the dashboard is also exposed as machine-readable JSON:
+
+```bash
+curl -sS http://127.0.0.1:8085/api/status
+```
+
+Returns a single snapshot at request time. The server's polling loop refreshes the underlying data every 10 seconds. Same security posture as the UI itself — no auth, reachable from anything on the LAN.
+
+### Response shape
+
+```json
+{
+  "system_status": {
+    "architecture": "amd64",
+    "architecture_supported": true,
+    "device_ip": "10.0.0.3",
+    "binary_path": "/root/monero/monerod",
+    "binary_ready": true,
+    "binary_version": "'Fluorine Fermi' (v0.18.4.5-release)",
+    "storage_path": "/root/.bitmonero",
+    "storage_free_gib": 5587.401,
+    "storage_ok": true,
+    "state": "Running (external)",
+    "process_owned": false,
+    "external_node_running": true,
+    "node_is_running": true
+  },
+  "update_status": {
+    "update_available": true,
+    "local_version": "0.18.4.5",
+    "remote_version": "0.18.5.0"
+  },
+  "node_stats": {
+    "nettype": "mainnet",
+    "sync": {
+      "synchronized": true,
+      "height": 3682974,
+      "target_height": 3682974,
+      "progress_fraction": 1.0,
+      "busy_syncing": false
+    },
+    "overview": {
+      "connections_total": 0,
+      "connections_incoming": 0,
+      "connections_outgoing": 0,
+      "block_height": 3682974,
+      "free_space_gib": 5587.401
+    },
+    "network": {
+      "hashrate": 6117779053,
+      "difficulty": 734133486418,
+      "peerlist_white": 0,
+      "peerlist_grey": 0,
+      "peerlist_total": 0
+    },
+    "blockchain": {
+      "tx_count": 60814079,
+      "tx_pool_size": 61,
+      "block_reward_atomic": 602031860000,
+      "fee_estimate_atomic": 20000,
+      "database_size_bytes": 279172874240
+    },
+    "resources": {
+      "bytes_in_mib": 0.0,
+      "bytes_out_mib": 0.0
+    },
+    "restricted_rpc": true,
+    "status": "OK"
+  },
+  "polling": {
+    "last_poll_time": 1779860213.436604,
+    "last_poll_error": null,
+    "poll_interval_secs": 10
+  }
+}
+```
+
+### Field notes
+
+- **`update_status`** is `null` until the startup version+update check completes (a few seconds after server start). If you're up-to-date, `update_available` is `false` and the banner is hidden in the UI.
+- **`node_stats`** is `null` until the first successful poll lands (1 second after the first page load). If the poll fails (daemon offline, RPC unreachable), `node_stats` stays at its last good value and `polling.last_poll_error` carries the error string.
+- **`restricted_rpc: true`** indicates monerod is running with `--restricted-rpc`. When true, these fields are **redacted to 0 by monerod itself**, not actually zero:
+  - `node_stats.overview.connections_*`
+  - `node_stats.network.peerlist_*`
+  - `node_stats.resources.bytes_*_mib`
+  
+  The data exists on the daemon; it just intentionally doesn't share it over RPC. The Kivy app and the web UI both show `*` for these in the visible UI; consumers of the JSON should treat zeros under `restricted_rpc: true` as "unknown".
+- **`*_atomic`** values are in atomic units (1 XMR = 10¹² atomic). Divide by 1e12 for XMR.
+- **`last_poll_time`** is a Unix timestamp (seconds, fractional). Clients can compute staleness as `now() - last_poll_time`.
+
+### Example: monitor sync height from a script
+
+```bash
+while true; do
+  curl -sS http://127.0.0.1:8085/api/status \
+    | jq -r '.node_stats.sync | "height=\(.height) sync=\(.synchronized)"'
+  sleep 30
+done
+```
+
+(That uses pipes — write it as a script, not a one-liner under the Claude Code Bash hook.)
+
+## Development
+
+### Local iteration loop
+
+```bash
+source .venv/bin/activate
+# Edit a file...
+# Restart by Ctrl-C'ing the running server and re-running:
+monerodui-web
+```
+
+There's no hot-reload — NiceGUI's `reload=True` doesn't play well with our startup hooks. Manual restart is the path.
+
+### Validating imports without launching the server
+
+```bash
+.venv/bin/python -c "import monerodui_web.main; print('OK')"
+```
+
+Catches syntax errors and missing imports without firing up the HTTP server.
+
+### Running both the Kivy app and the web UI simultaneously?
+
+**Don't.** Both read and write the same `~/.config/monerodui/monerodui.ini` — there's no file locking, so a race would lose writes. They'd also both try to spawn monerod subprocesses if either decided to auto-start. Run one or the other.
+
+### Tests
+
+There aren't any (yet). The end-to-end "test" is launch + browse. Settings parity vs the Kivy `settings_schema.json` was verified manually during the port; if you add a setting in either place, audit the other.
+
+## Known quirks
+
+- **`--restricted-rpc` redactions show as `*` in the UI** with an always-visible footnote explaining why. See the JSON API section above for the full list of affected fields.
+- **The version banner uses Monero's full release name** (`'Fluorine Fermi' (v0.18.4.5-release)`), not the short form (`v0.18.4.5`). Matches what the Kivy app shows.
+- **Status card collapse is a UI-only toggle**, not persisted to config. Reopening the page resets it to expanded.
+- **`ss -tlnp sport = :PORT`** triggers Claude Code's permission-prompt "parse error" path. If you script around the web UI from inside a Claude session, prefer `lsof -iTCP:PORT -sTCP:LISTEN`.
+
+## Related files
+
+- [`../../README.md`](../../README.md) — main monerodui README (covers the Kivy app, Android builds, and general project info).
+- [`../monerodui/settings/settings_schema.json`](../monerodui/settings/settings_schema.json) — source of truth for the settings page schema.

--- a/src/monerodui_web/__init__.py
+++ b/src/monerodui_web/__init__.py
@@ -1,0 +1,17 @@
+"""monerodui_web — NiceGUI-based web UI for monerod.
+
+A drop-in replacement for the KivyMD desktop UI, intended to run as a
+local web server on the same machine as monerod. Shares the same INI
+config file (`~/.config/monerodui/monerodui.ini`) and reuses the
+hardware-/process-/RPC-facing library code from `monerodui.libs`.
+
+This package is independent of the existing `monerodui` (Kivy) package
+and does not import any Kivy/KivyMD modules.
+
+NOTE: `main` is intentionally *not* re-exported at package level so that
+`import monerodui_web.core` works without NiceGUI installed (useful for
+testing config / state in isolation). Import the entry point directly:
+
+    from monerodui_web.main import main
+"""
+

--- a/src/monerodui_web/__main__.py
+++ b/src/monerodui_web/__main__.py
@@ -1,0 +1,6 @@
+"""Module entry point: `python -m monerodui_web` launches the web UI."""
+
+from monerodui_web.main import main
+
+if __name__ == "__main__":
+    main()

--- a/src/monerodui_web/components/__init__.py
+++ b/src/monerodui_web/components/__init__.py
@@ -1,0 +1,6 @@
+"""NiceGUI component builders for monerodui_web."""
+
+from .status_card import build_status_card
+from .node_stats_card import build_node_stats_card
+
+__all__ = ["build_status_card", "build_node_stats_card"]

--- a/src/monerodui_web/components/node_stats_card.py
+++ b/src/monerodui_web/components/node_stats_card.py
@@ -7,7 +7,7 @@ Mirrors `src/monerodui/components/node_stats_card.py` +
 Sections (top to bottom):
   1. Header row: title + (right-aligned) network-type tag.
   2. Update banner (only when an update is available).
-  3. Update banner (M4 populates; rendered conditionally).
+  3. Update banner (rendered conditionally when an update is available).
   4. Offline message (when last_stats is None / status == 'offline').
   5. Sync status line + linear progress bar.
   6. OVERVIEW grid (3 cols): Connections, Block Height, Free Space.
@@ -308,7 +308,7 @@ def build_node_stats_card() -> None:
         # card (status_card.py "Monerod Version" row), so the dedicated
         # version banner that used to live here has been removed.
 
-        # ---- Update banner (M4 populates state.update_status) ----
+        # ---- Update banner (state.update_status driven) ----
         # state.update_banner_dismissed gates this the same way.
         upd = state.update_status
         if (

--- a/src/monerodui_web/components/node_stats_card.py
+++ b/src/monerodui_web/components/node_stats_card.py
@@ -136,18 +136,109 @@ def _version_banner(version_text: str) -> None:
         ui.label("monerod").style(f"color: {DIM_COLOR}; font-size: 11px;")
 
 
-def _update_banner(update_text: str) -> None:
-    """Banner shown when UpdateChecker reports an update is available."""
-    with ui.row().classes("items-center w-full no-wrap").style(
+def _construct_download_url(arch: str, version: str) -> Optional[str]:
+    """Build the canonical downloads.getmonero.org URL for this arch +
+    version. Matches the URL monerod itself logs when an update is
+    available (see bitmonero.log lines like "Version X.Y.Z of monero
+    for linux-x64 is available: https://downloads.getmonero.org/...").
+
+    Arch values come from `ArchDetector` ("amd64" / "arm64" / "armhf").
+    Returns None for unrecognized arch — banner will hide the URL row.
+    """
+    # arch values from ArchDetector.detected_arch — see
+    # src/monerodui/libs/arch_detector.py ARCH_MAP.
+    platform_map = {
+        "amd64": "linux-x64",
+        "arm64": "linux-armv8",
+        "arm32": "linux-armv7",
+    }
+    platform = platform_map.get(arch)
+    if platform is None:
+        return None
+    return (
+        f"https://downloads.getmonero.org/cli/"
+        f"monero-{platform}-v{version}.tar.bz2"
+    )
+
+
+def _copy_to_clipboard(text: str, label: str) -> None:
+    """Copy `text` to the browser clipboard and notify."""
+    js = (
+        "navigator.clipboard && navigator.clipboard.writeText("
+        f"{text!r}"
+        ")"
+    )
+    ui.run_javascript(js)
+    ui.notify(f"{label} copied", type="positive")
+
+
+def _update_banner(
+    local: str,
+    remote: str,
+    remote_hash: str,
+    download_url: Optional[str],
+) -> None:
+    """Banner shown when UpdateChecker reports an update is available.
+
+    Includes:
+      - Version delta ("Current: X.Y.Z --> Latest: A.B.C")
+      - Download URL (clickable, opens in new tab) + copy button
+      - SHA256 hash + copy button
+
+    Mirrors the info monerod itself logs to bitmonero.log on update
+    availability, so the user has everything they need to verify and
+    install the new release without leaving the page.
+    """
+    with ui.row().classes("items-start w-full no-wrap").style(
         f"background-color: {BANNER_BG_UPDATE}; "
         "padding: 12px; border-radius: 8px; gap: 8px;"
     ):
-        ui.icon("error").style("color: #ff4d4d; font-size: 20px;")
-        with ui.column().style("gap: 2px;"):
+        ui.icon("error").style(
+            "color: #ff4d4d; font-size: 20px; margin-top: 2px;"
+        )
+        with ui.column().classes("w-full").style("gap: 4px;"):
             ui.label("Update Available").style(
                 "color: #ffcccc; font-size: 13px; font-weight: 700;"
             )
-            ui.label(update_text).style("color: #ffcccc; font-size: 12px;")
+            ui.label(f"Current: {local}  -->  Latest: {remote}").style(
+                "color: #ffcccc; font-size: 12px;"
+            )
+            if download_url:
+                with ui.row().classes("items-center w-full no-wrap").style(
+                    "gap: 6px; margin-top: 4px;"
+                ):
+                    ui.label("Download:").style(
+                        "color: #ffaaaa; font-size: 11px; font-weight: 600; "
+                        "min-width: 70px;"
+                    )
+                    ui.link(download_url, download_url, new_tab=True).style(
+                        "color: #ffe066; font-size: 11px; "
+                        "word-break: break-all; text-decoration: underline;"
+                    )
+                    ui.button(
+                        icon="content_copy",
+                        on_click=lambda u=download_url: _copy_to_clipboard(u, "URL"),
+                    ).props("flat dense round size=sm color=white").tooltip(
+                        "Copy URL"
+                    )
+            if remote_hash:
+                with ui.row().classes("items-center w-full no-wrap").style(
+                    "gap: 6px;"
+                ):
+                    ui.label("SHA256:").style(
+                        "color: #ffaaaa; font-size: 11px; font-weight: 600; "
+                        "min-width: 70px;"
+                    )
+                    ui.label(remote_hash).style(
+                        "color: #ffe066; font-size: 11px; "
+                        "font-family: monospace; word-break: break-all;"
+                    )
+                    ui.button(
+                        icon="content_copy",
+                        on_click=lambda h=remote_hash: _copy_to_clipboard(h, "SHA256"),
+                    ).props("flat dense round size=sm color=white").tooltip(
+                        "Copy hash"
+                    )
 
 
 def _offline_banner(error: Optional[str]) -> None:
@@ -225,7 +316,12 @@ def build_node_stats_card() -> None:
         if upd is not None and getattr(upd, "update_available", False):
             local = getattr(upd, "local_version", None) or "?"
             remote = getattr(upd, "remote_version", None) or "?"
-            _update_banner(f"Current: {local}  -->  Latest: {remote}")
+            remote_hash = getattr(upd, "remote_hash", "") or ""
+            # Construct the same download URL monerod itself logs to
+            # bitmonero.log when an update is available. Falls back to
+            # None (hides the URL row) if arch is unrecognized.
+            download_url = _construct_download_url(state.arch_name, remote)
+            _update_banner(local, remote, remote_hash, download_url)
 
         # ---- Offline message OR live grids ----
         if is_offline:

--- a/src/monerodui_web/components/node_stats_card.py
+++ b/src/monerodui_web/components/node_stats_card.py
@@ -248,12 +248,37 @@ def _offline_banner(error: Optional[str]) -> None:
         f"background-color: {BANNER_BG_OFFLINE}; padding: 24px; "
         "border-radius: 8px; gap: 4px;"
     ):
-        ui.label("Node is not running").style(
+        # Distinguish "truly stopped" from "alive but syncing". When
+        # external_node_busy is True, the daemon exists (pgrep found it)
+        # but RPC is unresponsive — show a useful message instead of
+        # the misleading "Node is not running".
+        if state.external_node_busy:
+            headline = "Node is syncing"
+            if state.sync_eta_minutes is not None:
+                blocks_part = (
+                    f" ({state.sync_blocks_left:,} blocks left)"
+                    if state.sync_blocks_left is not None else ""
+                )
+                detail = (
+                    f"~{state.sync_eta_minutes:.0f} minutes remaining"
+                    f"{blocks_part}. RPC will return when caught up."
+                )
+            else:
+                detail = (
+                    "Daemon is alive but RPC is busy. Stats will return "
+                    "automatically once it catches up."
+                )
+        else:
+            headline = "Node is not running"
+            detail = f"Last poll: {error}" if error else None
+
+        ui.label(headline).style(
             f"color: {DIM_COLOR}; font-size: 14px;"
         )
-        if error:
-            ui.label(f"Last poll: {error}").style(
-                f"color: {DIM_COLOR}; font-size: 11px; font-style: italic;"
+        if detail:
+            ui.label(detail).style(
+                f"color: {DIM_COLOR}; font-size: 11px; font-style: italic; "
+                "text-align: center; max-width: 480px;"
             )
 
 

--- a/src/monerodui_web/components/node_stats_card.py
+++ b/src/monerodui_web/components/node_stats_card.py
@@ -1,0 +1,310 @@
+"""Node statistics card — live view of monerod's RPC-reported state.
+
+Mirrors `src/monerodui/components/node_stats_card.py` +
+`src/monerodui/ui/components/node_stats_card.kv`. Driven by
+`AppState.last_stats` (a `monerodui.libs.NodeStats` dataclass).
+
+Sections (top to bottom):
+  1. Header row: title + (right-aligned) network-type tag.
+  2. Version banner (M4 populates; rendered conditionally).
+  3. Update banner (M4 populates; rendered conditionally).
+  4. Offline message (when last_stats is None / status == 'offline').
+  5. Sync status line + linear progress bar.
+  6. OVERVIEW grid (3 cols): Connections, Block Height, Free Space.
+  7. NETWORK grid (3 cols): Hashrate, Difficulty, Known Peers.
+  8. BLOCKCHAIN grid (5 cols): Total TXs, TX Pool, Block Reward,
+     Est. Fee, Database Size.
+  9. RESOURCES grid (2 cols): Bandwidth in, Bandwidth out.
+
+Color logic mirrors the Kivy KV's `is_ok` flag — orange #ff6600 for
+healthy, error red for unhealthy/zero. See `_stat_cell()`.
+
+No deployment-specific Configuration Variables.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from nicegui import ui
+
+from monerodui.libs import NodeStats
+from monerodui_web.core import state
+
+
+# Color palette — matches Kivy theme & status_card.py.
+OK_COLOR = "#ff6600"      # orange primary (Kivy [1, 0.4, 0, 1])
+ERR_COLOR = "#cf6679"     # Material dark error
+DIM_COLOR = "#999999"     # row labels (Kivy [0.6, 0.6, 0.6, 1])
+TEXT_COLOR = "#ffffff"
+HEADER_COLOR = "#ff6600"  # SECTION headers
+BANNER_BG_VERSION = "#262626"
+BANNER_BG_UPDATE = "rgba(204, 51, 51, 0.20)"
+BANNER_BG_OFFLINE = "#1a1a1a"
+
+
+# ---- Humanize helpers (module-private) -----------------------------------
+
+
+def _fmt_hashrate(hps: int) -> str:
+    """Bytes-style scaling for hash/s. Mirrors NodeStats.hashrate_display."""
+    if hps >= 1_000_000_000:
+        return f"{hps / 1_000_000_000:.2f} GH/s"
+    if hps >= 1_000_000:
+        return f"{hps / 1_000_000:.2f} MH/s"
+    if hps >= 1_000:
+        return f"{hps / 1_000:.2f} KH/s"
+    return f"{hps} H/s"
+
+
+def _fmt_difficulty(d: int) -> str:
+    """Mirrors NodeStats.difficulty_display."""
+    if d >= 1_000_000_000_000:
+        return f"{d / 1_000_000_000_000:.2f} TH"
+    if d >= 1_000_000_000:
+        return f"{d / 1_000_000_000:.2f} GH"
+    if d >= 1_000_000:
+        return f"{d / 1_000_000:.2f} MH"
+    return f"{d:,}"
+
+
+def _fmt_bytes_gib(n: int) -> str:
+    """Bytes -> GiB with 2 decimals."""
+    return f"{n / (1024 ** 3):.2f} GiB"
+
+
+def _fmt_atomic_xmr(atomic: int, decimals: int = 4) -> str:
+    """Monero atomic units (1e-12 XMR) -> XMR string. Mirrors NodeStats."""
+    if atomic == 0:
+        return "--"
+    xmr = atomic / 1_000_000_000_000
+    if xmr < 0.0001:
+        return f"{xmr:.8f}"
+    return f"{xmr:.{decimals}f}"
+
+
+# ---- Sub-builders --------------------------------------------------------
+
+
+def _section_header(text: str) -> None:
+    ui.label(text).style(
+        f"color: {HEADER_COLOR}; font-size: 12px; font-weight: 700; "
+        "letter-spacing: 1px; padding: 8px 0 4px 0;"
+    )
+
+
+def _stat_cell(value: str, label: str, is_ok: bool = True) -> None:
+    """OVERVIEW grid cell: bold colored value + dim label below."""
+    color = OK_COLOR if is_ok else ERR_COLOR
+    with ui.column().classes("items-center").style(
+        "gap: 2px; padding: 4px 8px; flex: 1;"
+    ):
+        ui.label(value).style(
+            f"color: {color}; font-size: 18px; font-weight: 700; "
+            "text-align: center;"
+        )
+        ui.label(label).style(
+            f"color: {DIM_COLOR}; font-size: 11px; text-align: center;"
+        )
+
+
+def _small_stat_cell(value: str, label: str) -> None:
+    """NETWORK/BLOCKCHAIN/RESOURCES grid cell: white value + dim label."""
+    with ui.column().classes("items-center").style(
+        "gap: 2px; padding: 4px 8px; flex: 1;"
+    ):
+        ui.label(value).style(
+            f"color: {TEXT_COLOR}; font-size: 14px; font-weight: 600; "
+            "text-align: center;"
+        )
+        ui.label(label).style(
+            f"color: {DIM_COLOR}; font-size: 11px; text-align: center;"
+        )
+
+
+def _version_banner(version_text: str) -> None:
+    """Top-of-card banner showing the local monerod binary version."""
+    with ui.row().classes("items-center w-full no-wrap").style(
+        f"background-color: {BANNER_BG_VERSION}; "
+        "padding: 8px 12px; border-radius: 8px; gap: 8px;"
+    ):
+        ui.icon("info").style(f"color: {DIM_COLOR}; font-size: 18px;")
+        ui.label(version_text).style(
+            f"color: #e6e6e6; font-size: 13px;"
+        )
+        ui.space()
+        ui.label("monerod").style(f"color: {DIM_COLOR}; font-size: 11px;")
+
+
+def _update_banner(update_text: str) -> None:
+    """Banner shown when UpdateChecker reports an update is available."""
+    with ui.row().classes("items-center w-full no-wrap").style(
+        f"background-color: {BANNER_BG_UPDATE}; "
+        "padding: 12px; border-radius: 8px; gap: 8px;"
+    ):
+        ui.icon("error").style("color: #ff4d4d; font-size: 20px;")
+        with ui.column().style("gap: 2px;"):
+            ui.label("Update Available").style(
+                "color: #ffcccc; font-size: 13px; font-weight: 700;"
+            )
+            ui.label(update_text).style("color: #ffcccc; font-size: 12px;")
+
+
+def _offline_banner(error: Optional[str]) -> None:
+    with ui.column().classes("items-center w-full").style(
+        f"background-color: {BANNER_BG_OFFLINE}; padding: 24px; "
+        "border-radius: 8px; gap: 4px;"
+    ):
+        ui.label("Node is not running").style(
+            f"color: {DIM_COLOR}; font-size: 14px;"
+        )
+        if error:
+            ui.label(f"Last poll: {error}").style(
+                f"color: {DIM_COLOR}; font-size: 11px; font-style: italic;"
+            )
+
+
+def _sync_section(stats: NodeStats) -> None:
+    """Sync status text + linear progress bar."""
+    # Status text (mirror Kivy logic).
+    if stats.synchronized:
+        status_text = "Fully synchronized"
+    elif stats.busy_syncing:
+        status_text = (
+            f"Syncing... {stats.height:,} / {stats.target_height:,} "
+            f"({stats.sync_progress:.1f}%) — "
+            f"{stats.blocks_remaining:,} blocks remaining"
+        )
+    else:
+        status_text = "Waiting for sync..."
+
+    with ui.column().classes("w-full").style("gap: 4px;"):
+        ui.label(status_text).style(
+            f"color: {DIM_COLOR}; font-size: 12px;"
+        )
+        # ui.linear_progress takes 0.0-1.0. NodeStats.sync_progress is 0-100.
+        ui.linear_progress(
+            value=stats.sync_progress / 100.0,
+            show_value=False,
+        ).props("color=orange instant-feedback").style("height: 16px;")
+
+
+# ---- Main refreshable builder --------------------------------------------
+
+
+@ui.refreshable
+def build_node_stats_card() -> None:
+    """Build the node-stats card from current `AppState`."""
+    stats = state.last_stats
+    is_offline = stats is None or stats.status == "offline"
+
+    with ui.card().classes("w-full").style(
+        "background-color: #000000; border: 1px solid #1a1a1a; "
+        "padding: 16px; border-radius: 8px; gap: 12px;"
+    ):
+        # ---- Header row ----
+        with ui.row().classes("items-center w-full no-wrap").style("gap: 8px;"):
+            ui.label("Node Statistics").style(
+                f"color: {TEXT_COLOR}; font-size: 18px; font-weight: 600;"
+            )
+            ui.space()
+            if not is_offline and stats is not None:
+                ui.label(stats.nettype.upper()).style(
+                    f"color: {OK_COLOR}; font-size: 11px; font-weight: 700; "
+                    "letter-spacing: 1px;"
+                )
+
+        ui.separator().style("background-color: #333333;")
+
+        # ---- Version banner (M4 populates state.binary_version) ----
+        if state.binary_version:
+            _version_banner(state.binary_version)
+
+        # ---- Update banner (M4 populates state.update_status) ----
+        upd = state.update_status
+        if upd is not None and getattr(upd, "update_available", False):
+            local = getattr(upd, "local_version", None) or "?"
+            remote = getattr(upd, "remote_version", None) or "?"
+            _update_banner(f"Current: {local}  -->  Latest: {remote}")
+
+        # ---- Offline message OR live grids ----
+        if is_offline:
+            _offline_banner(state.last_poll_error)
+            return
+
+        assert stats is not None  # narrowed by is_offline check
+        _sync_section(stats)
+
+        # OVERVIEW (3 cols)
+        _section_header("OVERVIEW")
+        with ui.row().classes("w-full no-wrap").style("gap: 4px;"):
+            # incoming_connections_count + outgoing_connections_count are
+            # both redacted to 0 by --restricted-rpc. The daemon may have
+            # plenty of real peers (verifiable via `lsof -iTCP:18080`);
+            # show "*" so the UI is honest about not knowing rather than
+            # claiming "0 peers" misleadingly. The footnote in
+            # dashboard.py (between the scroll area and Start/Stop button)
+            # explains the asterisk.
+            if stats.total_connections == 0:
+                conn_value = "*"
+                conn_ok = True  # don't paint red — we just don't know
+            else:
+                conn_value = f"{stats.total_connections}"
+                conn_ok = stats.total_connections > 0
+            _stat_cell(conn_value, "Connections", is_ok=conn_ok)
+            _stat_cell(
+                f"{stats.height:,}",
+                "Block Height",
+                is_ok=stats.synchronized,
+            )
+            # Prefer state.storage_free_gib (set from os.statvfs at init)
+            # over stats.free_space_gib — they should be close, but the
+            # config-derived path is what the user is actually using.
+            free_gib = (
+                state.storage_free_gib
+                if state.storage_free_gib > 0
+                else stats.free_space_gib
+            )
+            _stat_cell(
+                f"{free_gib:.1f} GiB",
+                "Free Space",
+                is_ok=free_gib > 1.0,
+            )
+
+        # NETWORK (3 cols)
+        _section_header("NETWORK")
+        with ui.row().classes("w-full no-wrap").style("gap: 4px;"):
+            _small_stat_cell(_fmt_hashrate(stats.hashrate), "Hashrate")
+            _small_stat_cell(_fmt_difficulty(stats.difficulty), "Difficulty")
+            # white_peerlist_size + grey_peerlist_size both redacted to 0
+            # under --restricted-rpc. Show "*" instead of misleading "0";
+            # page-level footnote in dashboard.py explains.
+            peers_total = stats.white_peerlist_size + stats.grey_peerlist_size
+            peers_value = "*" if peers_total == 0 else f"{peers_total:,}"
+            _small_stat_cell(peers_value, "Known Peers")
+
+        # BLOCKCHAIN (5 cols)
+        _section_header("BLOCKCHAIN")
+        with ui.row().classes("w-full no-wrap").style("gap: 4px;"):
+            _small_stat_cell(f"{stats.tx_count:,}", "Total TXs")
+            _small_stat_cell(f"{stats.tx_pool_size:,}", "TX Pool")
+            _small_stat_cell(_fmt_atomic_xmr(stats.block_reward), "Block Reward")
+            _small_stat_cell(_fmt_atomic_xmr(stats.fee_estimate, 8), "Est. Fee (XMR)")
+            _small_stat_cell(_fmt_bytes_gib(stats.database_size), "Database Size")
+
+        # RESOURCES (2 cols)
+        _section_header("RESOURCES")
+        with ui.row().classes("w-full no-wrap").style("gap: 4px;"):
+            # bytes_in_mib / bytes_out_mib are both 0 when --restricted-rpc
+            # blocks GET /get_net_stats (returns 404; the poller swallows
+            # the error and reports 0). Render "*" so the user knows the
+            # data is unavailable, not literally zero; page-level footnote
+            # in dashboard.py explains.
+            if stats.bytes_in_mib == 0.0 and stats.bytes_out_mib == 0.0:
+                bw_down_value = "*"
+                bw_up_value = "*"
+            else:
+                bw_down_value = f"{stats.bytes_in_mib:.1f} MiB"
+                bw_up_value = f"{stats.bytes_out_mib:.1f} MiB"
+            _small_stat_cell(bw_down_value, "Bandwidth Down")
+            _small_stat_cell(bw_up_value, "Bandwidth Up")

--- a/src/monerodui_web/components/node_stats_card.py
+++ b/src/monerodui_web/components/node_stats_card.py
@@ -30,6 +30,7 @@ from nicegui import ui
 
 from monerodui.libs import NodeStats
 from monerodui_web.core import state
+from monerodui_web.core.monero_release import construct_download_url
 
 
 # Color palette — matches Kivy theme & status_card.py.
@@ -151,31 +152,6 @@ def _version_banner(version_text: str) -> None:
         ).props("flat dense round size=sm color=white").tooltip(
             "Dismiss (returns on next service restart)"
         )
-
-
-def _construct_download_url(arch: str, version: str) -> Optional[str]:
-    """Build the canonical downloads.getmonero.org URL for this arch +
-    version. Matches the URL monerod itself logs when an update is
-    available (see bitmonero.log lines like "Version X.Y.Z of monero
-    for linux-x64 is available: https://downloads.getmonero.org/...").
-
-    Arch values come from `ArchDetector` ("amd64" / "arm64" / "armhf").
-    Returns None for unrecognized arch — banner will hide the URL row.
-    """
-    # arch values from ArchDetector.detected_arch — see
-    # src/monerodui/libs/arch_detector.py ARCH_MAP.
-    platform_map = {
-        "amd64": "linux-x64",
-        "arm64": "linux-armv8",
-        "arm32": "linux-armv7",
-    }
-    platform = platform_map.get(arch)
-    if platform is None:
-        return None
-    return (
-        f"https://downloads.getmonero.org/cli/"
-        f"monero-{platform}-v{version}.tar.bz2"
-    )
 
 
 def _copy_to_clipboard(text: str, label: str) -> None:
@@ -353,7 +329,7 @@ def build_node_stats_card() -> None:
             # Construct the same download URL monerod itself logs to
             # bitmonero.log when an update is available. Falls back to
             # None (hides the URL row) if arch is unrecognized.
-            download_url = _construct_download_url(state.arch_name, remote)
+            download_url = construct_download_url(state.arch_name, remote)
             _update_banner(local, remote, remote_hash, download_url)
 
         # ---- Offline message OR live grids ----

--- a/src/monerodui_web/components/node_stats_card.py
+++ b/src/monerodui_web/components/node_stats_card.py
@@ -122,6 +122,18 @@ def _small_stat_cell(value: str, label: str) -> None:
         )
 
 
+def _dismiss_version_banner() -> None:
+    """Hide the version banner for the rest of this server process."""
+    state.version_banner_dismissed = True
+    build_node_stats_card.refresh()
+
+
+def _dismiss_update_banner() -> None:
+    """Hide the update banner for the rest of this server process."""
+    state.update_banner_dismissed = True
+    build_node_stats_card.refresh()
+
+
 def _version_banner(version_text: str) -> None:
     """Top-of-card banner showing the local monerod binary version."""
     with ui.row().classes("items-center w-full no-wrap").style(
@@ -134,6 +146,11 @@ def _version_banner(version_text: str) -> None:
         )
         ui.space()
         ui.label("monerod").style(f"color: {DIM_COLOR}; font-size: 11px;")
+        ui.button(
+            icon="close", on_click=_dismiss_version_banner
+        ).props("flat dense round size=sm color=white").tooltip(
+            "Dismiss (returns on next service restart)"
+        )
 
 
 def _construct_download_url(arch: str, version: str) -> Optional[str]:
@@ -197,9 +214,18 @@ def _update_banner(
             "color: #ff4d4d; font-size: 20px; margin-top: 2px;"
         )
         with ui.column().classes("w-full").style("gap: 4px;"):
-            ui.label("Update Available").style(
-                "color: #ffcccc; font-size: 13px; font-weight: 700;"
-            )
+            with ui.row().classes("items-center w-full no-wrap").style(
+                "gap: 4px;"
+            ):
+                ui.label("Update Available").style(
+                    "color: #ffcccc; font-size: 13px; font-weight: 700;"
+                )
+                ui.space()
+                ui.button(
+                    icon="close", on_click=_dismiss_update_banner
+                ).props("flat dense round size=sm color=white").tooltip(
+                    "Dismiss (returns on next service restart)"
+                )
             ui.label(f"Current: {local}  -->  Latest: {remote}").style(
                 "color: #ffcccc; font-size: 12px;"
             )
@@ -308,12 +334,19 @@ def build_node_stats_card() -> None:
         ui.separator().style("background-color: #333333;")
 
         # ---- Version banner (M4 populates state.binary_version) ----
-        if state.binary_version:
+        # state.version_banner_dismissed is set when the user clicks the
+        # banner's X — persists for the rest of this server process.
+        if state.binary_version and not state.version_banner_dismissed:
             _version_banner(state.binary_version)
 
         # ---- Update banner (M4 populates state.update_status) ----
+        # state.update_banner_dismissed gates this the same way.
         upd = state.update_status
-        if upd is not None and getattr(upd, "update_available", False):
+        if (
+            upd is not None
+            and getattr(upd, "update_available", False)
+            and not state.update_banner_dismissed
+        ):
             local = getattr(upd, "local_version", None) or "?"
             remote = getattr(upd, "remote_version", None) or "?"
             remote_hash = getattr(upd, "remote_hash", "") or ""

--- a/src/monerodui_web/components/node_stats_card.py
+++ b/src/monerodui_web/components/node_stats_card.py
@@ -30,6 +30,7 @@ from nicegui import ui
 
 from monerodui.libs import NodeStats
 from monerodui_web.core import state
+from monerodui_web.core.clipboard import copy_text
 from monerodui_web.core.monero_release import construct_download_url
 
 
@@ -155,13 +156,8 @@ def _version_banner(version_text: str) -> None:
 
 
 def _copy_to_clipboard(text: str, label: str) -> None:
-    """Copy `text` to the browser clipboard and notify."""
-    js = (
-        "navigator.clipboard && navigator.clipboard.writeText("
-        f"{text!r}"
-        ")"
-    )
-    ui.run_javascript(js)
+    """Copy `text` to the browser clipboard via the shared helper."""
+    copy_text(text)
     ui.notify(f"{label} copied", type="positive")
 
 

--- a/src/monerodui_web/components/node_stats_card.py
+++ b/src/monerodui_web/components/node_stats_card.py
@@ -6,7 +6,7 @@ Mirrors `src/monerodui/components/node_stats_card.py` +
 
 Sections (top to bottom):
   1. Header row: title + (right-aligned) network-type tag.
-  2. Version banner (M4 populates; rendered conditionally).
+  2. Update banner (only when an update is available).
   3. Update banner (M4 populates; rendered conditionally).
   4. Offline message (when last_stats is None / status == 'offline').
   5. Sync status line + linear progress bar.
@@ -40,7 +40,6 @@ ERR_COLOR = "#cf6679"     # Material dark error
 DIM_COLOR = "#999999"     # row labels (Kivy [0.6, 0.6, 0.6, 1])
 TEXT_COLOR = "#ffffff"
 HEADER_COLOR = "#ff6600"  # SECTION headers
-BANNER_BG_VERSION = "#262626"
 BANNER_BG_UPDATE = "rgba(204, 51, 51, 0.20)"
 BANNER_BG_OFFLINE = "#1a1a1a"
 
@@ -124,35 +123,10 @@ def _small_stat_cell(value: str, label: str) -> None:
         )
 
 
-def _dismiss_version_banner() -> None:
-    """Hide the version banner for the rest of this server process."""
-    state.version_banner_dismissed = True
-    build_node_stats_card.refresh()
-
-
 def _dismiss_update_banner() -> None:
     """Hide the update banner for the rest of this server process."""
     state.update_banner_dismissed = True
     build_node_stats_card.refresh()
-
-
-def _version_banner(version_text: str) -> None:
-    """Top-of-card banner showing the local monerod binary version."""
-    with ui.row().classes("items-center w-full no-wrap").style(
-        f"background-color: {BANNER_BG_VERSION}; "
-        "padding: 8px 12px; border-radius: 8px; gap: 8px;"
-    ):
-        ui.icon("info").style(f"color: {DIM_COLOR}; font-size: 18px;")
-        ui.label(version_text).style(
-            f"color: #e6e6e6; font-size: 13px;"
-        )
-        ui.space()
-        ui.label("monerod").style(f"color: {DIM_COLOR}; font-size: 11px;")
-        ui.button(
-            icon="close", on_click=_dismiss_version_banner
-        ).props("flat dense round size=sm color=white").tooltip(
-            "Dismiss (returns on next service restart)"
-        )
 
 
 def _copy_to_clipboard(text: str, label: str) -> None:
@@ -330,11 +304,9 @@ def build_node_stats_card() -> None:
 
         ui.separator().style("background-color: #333333;")
 
-        # ---- Version banner (M4 populates state.binary_version) ----
-        # state.version_banner_dismissed is set when the user clicks the
-        # banner's X — persists for the rest of this server process.
-        if state.binary_version and not state.version_banner_dismissed:
-            _version_banner(state.binary_version)
+        # The monerod version is now displayed in the System Status
+        # card (status_card.py "Monerod Version" row), so the dedicated
+        # version banner that used to live here has been removed.
 
         # ---- Update banner (M4 populates state.update_status) ----
         # state.update_banner_dismissed gates this the same way.

--- a/src/monerodui_web/components/status_card.py
+++ b/src/monerodui_web/components/status_card.py
@@ -142,7 +142,19 @@ def build_status_card() -> None:
             state.binary_ready,
         )
 
-        # 4. Storage (clickable when node is stopped — picker lands in M3)
+        # 4. Monerod Version (populated by M4's VersionChecker; shown
+        # here in System Status — used to live as a banner inside the
+        # Node Statistics card but the row consolidation reads better
+        # alongside Architecture / Binary).
+        version_display = state.binary_version or "—"
+        _status_row(
+            "verified",
+            "Monerod Version",
+            version_display,
+            state.binary_version is not None,
+        )
+
+        # 5. Storage (clickable when node is stopped — picker lands in M3)
         if state.storage_ok and state.storage_path:
             storage_display = (
                 f"{state.storage_path} ({state.storage_free_gib:.1f} GiB free)"
@@ -171,7 +183,7 @@ def build_status_card() -> None:
             ),
         )
 
-        # 5. State — tri-state, distinguishes owned vs external monerod.
+        # 6. State — tri-state, distinguishes owned vs external monerod.
         # The Stop button in the dashboard footer keys off the same
         # process_owned / external_node_running flags.
         if state.process_owned:

--- a/src/monerodui_web/components/status_card.py
+++ b/src/monerodui_web/components/status_card.py
@@ -1,0 +1,200 @@
+"""Status card — the system-status panel.
+
+Mirrors the Kivy `StatusCard` (src/monerodui/components/status_card.py
++ src/monerodui/ui/components/status_card.kv). Five rows:
+Architecture, Device IP, Binary, Storage, State. Color coding follows
+the Kivy theme: orange #ff6600 for OK, theme error red for problems.
+
+Live state-text updates drive off `AppState` mutated by the polling
+tick in dashboard.py; call `build_status_card.refresh()` to re-render.
+Start/Stop button lives separately in the dashboard footer (not in
+this card). Storage row's chevron always navigates to `/settings` so
+the user can change `advanced.data_dir`.
+
+No deployment-specific Configuration Variables in this file.
+"""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from monerodui_web.core import state
+
+# Color palette — matches the Kivy theme.
+OK_COLOR = "#ff6600"        # orange primary (Kivy [1, 0.4, 0, 1])
+ERR_COLOR = "#cf6679"       # Material dark error
+DIM_COLOR = "#999999"        # row labels (Kivy [0.6, 0.6, 0.6, 1])
+TEXT_COLOR = "#ffffff"
+SUMMARY_DIM = "#b3b3b3"
+
+
+def _status_row(
+    icon: str,
+    label: str,
+    value: str,
+    is_ok: bool,
+    *,
+    trailing_icon: str | None = None,
+    trailing_disabled: bool = False,
+    trailing_on_click=None,
+) -> None:
+    """Render one Architecture/IP/Binary/Storage/State row."""
+    color = OK_COLOR if is_ok else ERR_COLOR
+    with ui.row().classes("items-center w-full no-wrap").style(
+        "padding: 8px 0; gap: 12px;"
+    ):
+        ui.icon(icon).style(f"color: {color}; font-size: 24px;")
+        ui.label(label).style(
+            f"color: {DIM_COLOR}; width: 40%; "
+            "overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+        )
+        ui.label(value).style(
+            f"color: {TEXT_COLOR}; font-weight: 600; flex: 1; "
+            "overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
+        )
+        if trailing_icon is not None:
+            btn = ui.button(icon=trailing_icon, on_click=trailing_on_click).props(
+                "flat round dense color=white"
+            )
+            if trailing_disabled:
+                btn.disable()
+
+
+@ui.refreshable
+def build_status_card() -> None:
+    """Build the status card from current `AppState`.
+
+    Call `build_status_card.refresh()` from anywhere to re-render
+    after `state` mutates (M2/M4).
+    """
+    # Card matches Kivy: black background, no border, outlined-look.
+    with ui.card().classes("w-full").style(
+        "background-color: #000000; border: 1px solid #1a1a1a; "
+        "padding: 16px; border-radius: 8px;"
+    ):
+        # ---- Header ----
+        with ui.row().classes("items-center w-full no-wrap").style("gap: 8px;"):
+            ui.label("System Status").style(
+                f"color: {TEXT_COLOR}; font-size: 18px; font-weight: 600;"
+            )
+            ui.space()
+            # Right-aligned summary text: when running, show storage path;
+            # when stopped, show "Stopped" so a collapsed card still has
+            # state context in its header.
+            if state.node_is_running:
+                ui.label(
+                    f"[ Running • {state.storage_path or '--'} ]"
+                ).style(f"color: {SUMMARY_DIM}; font-size: 12px;")
+            elif state.status_card_collapsed:
+                ui.label("[ Stopped ]").style(
+                    f"color: {SUMMARY_DIM}; font-size: 12px;"
+                )
+            # Collapse/expand toggle. Icon mirrors current state so the
+            # user can predict what clicking will do.
+            ui.button(
+                icon=(
+                    "expand_more" if state.status_card_collapsed
+                    else "expand_less"
+                ),
+                on_click=_toggle_status_card_collapsed,
+            ).props("flat round dense color=white")
+
+        # Body — hidden when collapsed. The separator + rows are the
+        # collapsible part; the header stays visible regardless.
+        if state.status_card_collapsed:
+            return
+
+        ui.separator().style("background-color: #333333; margin: 8px 0;")
+
+        # ---- Rows ----
+
+        # 1. Architecture
+        arch_ok = state.arch_supported
+        arch_display = state.arch_name if arch_ok else f"{state.arch_name} (unsupported)"
+        _status_row("memory", "Architecture", arch_display, arch_ok)
+
+        # 2. Device IP (with copy button)
+        ip_ok = state.device_ip not in ("Unknown", "No Ext Net", "")
+        _status_row(
+            "lan",
+            "Device IP",
+            state.device_ip,
+            ip_ok,
+            trailing_icon="content_copy",
+            trailing_disabled=not ip_ok,
+            trailing_on_click=(
+                (lambda: _copy_to_clipboard(state.device_ip)) if ip_ok else None
+            ),
+        )
+
+        # 3. Binary
+        if state.binary_ready and state.binary_path:
+            bin_display = "Ready"
+        elif state.binary_path:
+            bin_display = "Not Executable"
+        else:
+            bin_display = "Not Found"
+        _status_row(
+            "settings_applications",
+            "Binary",
+            bin_display,
+            state.binary_ready,
+        )
+
+        # 4. Storage (clickable when node is stopped — picker lands in M3)
+        if state.storage_ok and state.storage_path:
+            storage_display = (
+                f"{state.storage_path} ({state.storage_free_gib:.1f} GiB free)"
+            )
+        elif state.storage_path:
+            storage_display = f"{state.storage_path} - low free space"
+        else:
+            storage_display = "Not configured"
+        # Chevron always navigates to /settings (Advanced section, where
+        # the data-dir picker lives). M3 ships a proper picker; changes
+        # take effect on the next daemon restart. Always-clickable so the
+        # affordance isn't a lie when a daemon happens to be running.
+        _status_row(
+            "storage",
+            "Storage",
+            storage_display,
+            state.storage_ok,
+            trailing_icon="chevron_right",
+            trailing_disabled=False,
+            trailing_on_click=lambda: ui.navigate.to("/settings"),
+        )
+
+        # 5. State — tri-state, distinguishes owned vs external monerod.
+        # The Stop button in the dashboard footer keys off the same
+        # process_owned / external_node_running flags.
+        if state.process_owned:
+            state_text = "Running"
+            state_icon = "play_circle"
+            state_ok = True
+        elif state.external_node_running:
+            state_text = "Running (external)"
+            state_icon = "play_circle"
+            state_ok = True
+        else:
+            state_text = "Stopped"
+            state_icon = "stop_circle"
+            state_ok = False
+        _status_row(state_icon, "State", state_text, state_ok)
+
+
+def _toggle_status_card_collapsed() -> None:
+    """Flip the collapsed flag and re-render the card."""
+    state.status_card_collapsed = not state.status_card_collapsed
+    build_status_card.refresh()
+
+
+def _copy_to_clipboard(text: str) -> None:
+    """Copy `text` to the browser clipboard via JS."""
+    # navigator.clipboard requires a secure context (localhost counts).
+    js = (
+        "navigator.clipboard && navigator.clipboard.writeText("
+        f"{text!r}"
+        ")"
+    )
+    ui.run_javascript(js)
+    ui.notify(f"Copied: {text}", type="positive")

--- a/src/monerodui_web/components/status_card.py
+++ b/src/monerodui_web/components/status_card.py
@@ -175,6 +175,24 @@ def build_status_card() -> None:
             state_text = "Running (external)"
             state_icon = "play_circle"
             state_ok = True
+        elif state.external_node_busy:
+            # External monerod is alive (pgrep found it) but its RPC is
+            # unresponsive — usually means it's busy syncing. Not an
+            # error state, so don't paint red. If we managed to parse
+            # an ETA from monerod's log, append it to the label.
+            if state.sync_eta_minutes is not None:
+                blocks_part = (
+                    f", {state.sync_blocks_left:,} blocks left"
+                    if state.sync_blocks_left is not None else ""
+                )
+                state_text = (
+                    f"Running (syncing — ~{state.sync_eta_minutes:.0f}m"
+                    f"{blocks_part})"
+                )
+            else:
+                state_text = "Running (syncing)"
+            state_icon = "sync"
+            state_ok = True
         else:
             state_text = "Stopped"
             state_icon = "stop_circle"

--- a/src/monerodui_web/components/status_card.py
+++ b/src/monerodui_web/components/status_card.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from nicegui import ui
 
 from monerodui_web.core import state
+from monerodui_web.core.clipboard import copy_text
 
 # Color palette — matches the Kivy theme.
 OK_COLOR = "#ff6600"        # orange primary (Kivy [1, 0.4, 0, 1])
@@ -213,12 +214,6 @@ def _toggle_status_card_collapsed() -> None:
 
 
 def _copy_to_clipboard(text: str) -> None:
-    """Copy `text` to the browser clipboard via JS."""
-    # navigator.clipboard requires a secure context (localhost counts).
-    js = (
-        "navigator.clipboard && navigator.clipboard.writeText("
-        f"{text!r}"
-        ")"
-    )
-    ui.run_javascript(js)
+    """Copy `text` to the browser clipboard via the shared helper."""
+    copy_text(text)
     ui.notify(f"Copied: {text}", type="positive")

--- a/src/monerodui_web/components/status_card.py
+++ b/src/monerodui_web/components/status_card.py
@@ -161,7 +161,13 @@ def build_status_card() -> None:
             state.storage_ok,
             trailing_icon="chevron_right",
             trailing_disabled=False,
-            trailing_on_click=lambda: ui.navigate.to("/settings"),
+            # Land on the Advanced section with the data_dir input
+            # briefly flashed — much more useful than dumping the user
+            # at the top of the settings page. See settings_route() for
+            # the focus query-param handling.
+            trailing_on_click=lambda: ui.navigate.to(
+                "/settings?focus=advanced.data_dir"
+            ),
         )
 
         # 5. State — tri-state, distinguishes owned vs external monerod.

--- a/src/monerodui_web/components/status_card.py
+++ b/src/monerodui_web/components/status_card.py
@@ -66,7 +66,7 @@ def build_status_card() -> None:
     """Build the status card from current `AppState`.
 
     Call `build_status_card.refresh()` from anywhere to re-render
-    after `state` mutates (M2/M4).
+    after `state` mutates.
     """
     # Card matches Kivy: black background, no border, outlined-look.
     with ui.card().classes("w-full").style(
@@ -142,7 +142,7 @@ def build_status_card() -> None:
             state.binary_ready,
         )
 
-        # 4. Monerod Version (populated by M4's VersionChecker; shown
+        # 4. Monerod Version (populated by VersionChecker; shown
         # here in System Status — used to live as a banner inside the
         # Node Statistics card but the row consolidation reads better
         # alongside Architecture / Binary).
@@ -154,7 +154,7 @@ def build_status_card() -> None:
             state.binary_version is not None,
         )
 
-        # 5. Storage (clickable when node is stopped — picker lands in M3)
+        # 5. Storage (clickable — chevron jumps to the settings page)
         if state.storage_ok and state.storage_path:
             storage_display = (
                 f"{state.storage_path} ({state.storage_free_gib:.1f} GiB free)"
@@ -164,7 +164,7 @@ def build_status_card() -> None:
         else:
             storage_display = "Not configured"
         # Chevron always navigates to /settings (Advanced section, where
-        # the data-dir picker lives). M3 ships a proper picker; changes
+        # the data-dir picker lives). The settings page has a proper picker; changes
         # take effect on the next daemon restart. Always-clickable so the
         # affordance isn't a lie when a daemon happens to be running.
         _status_row(

--- a/src/monerodui_web/core/__init__.py
+++ b/src/monerodui_web/core/__init__.py
@@ -1,0 +1,11 @@
+"""Core (non-UI) state and config for monerodui_web."""
+
+from .app_state import AppState, state
+from .config_manager import ConfigManager, config
+
+__all__ = [
+    "AppState",
+    "state",
+    "ConfigManager",
+    "config",
+]

--- a/src/monerodui_web/core/app_state.py
+++ b/src/monerodui_web/core/app_state.py
@@ -16,8 +16,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 # Imported from the existing libs package (which has zero Kivy deps).
-# Importing the type here keeps `state.last_stats` correctly typed even
-# though M1 never sets it (poll is M2).
+# Importing the type here keeps `state.last_stats` correctly typed.
 from monerodui.libs import NodeStats  # noqa: F401  (re-exported via type hint)
 
 
@@ -25,15 +24,14 @@ from monerodui.libs import NodeStats  # noqa: F401  (re-exported via type hint)
 class AppState:
     """Singleton holding all UI-observable state.
 
-    Lifecycle of each field:
-      - process_owned / external_node_running / node_state / last_stats /
-        last_poll_time / last_poll_error:
-            written by the stats poller / process_adapter (M2).
+    Where each field is written:
+      - process_owned / external_node_running / external_node_busy /
+        node_state / last_stats / last_poll_time / last_poll_error:
+            stats poller + process_adapter (per-tick in dashboard.py).
       - binary_version / update_status:
-            written by VersionChecker / UpdateChecker (M4). M1/M2 leave
-            them at defaults (M2 renders banners conditionally).
+            VersionChecker / UpdateChecker (one-shot on startup).
       - arch_*, binary_*, storage_*, device_ip:
-            populated once at startup by `main.initialize()` (M1).
+            populated once at startup by `main.initialize()`.
 
     `node_is_running` is a *derived* property: true if EITHER we own the
     process OR an external monerod is reachable via RPC. Use the two
@@ -41,7 +39,7 @@ class AppState:
     external-only).
     """
 
-    # ---- Node lifecycle (M2) ----
+    # ---- Node lifecycle ----
     # Did *we* spawn this monerod? Drives whether Stop is enabled.
     process_owned: bool = False
     # Is there an RPC-reachable monerod we did NOT spawn? Surfaces as
@@ -77,7 +75,7 @@ class AppState:
     # process_adapter on failed start/stop.
     last_error: Optional[str] = None
 
-    # ---- Live service references (M2 populates from main.initialize) ----
+    # ---- Live service references (populated from main.initialize) ----
     # Typed as Any to avoid an import cycle; concrete types are
     # monerodui.libs.ProcessManager, NodeStatsPoller, VersionChecker,
     # UpdateChecker.
@@ -86,31 +84,31 @@ class AppState:
     version_checker: Optional[Any] = None
     update_checker: Optional[Any] = None
 
-    # ---- Binary metadata (M4 writes, M1/M2 leave defaults) ----
+    # ---- Binary metadata (written by the version + update checks) ----
     binary_version: Optional[str] = None
     update_status: Optional[Any] = None  # UpdateStatus from libs.update_checker
 
-    # ---- Arch / binary readiness (M1 populates) ----
+    # ---- Arch / binary readiness (populated at startup) ----
     arch_supported: bool = False
     arch_name: str = "Unknown"
     binary_path: Optional[Path] = None
     binary_ready: bool = False
 
-    # ---- Storage check (M1 populates) ----
+    # ---- Storage check (populated at startup) ----
     storage_path: Optional[str] = None
     storage_free_gib: float = 0.0
     storage_ok: bool = False
-    # M4: one-shot flag so the low-storage warning toast fires exactly
-    # once across the server's lifetime — first browser to connect to
-    # the dashboard sees it; subsequent reloads / tabs do not. Reset
-    # to False if you want it to re-fire (e.g. after a config change
-    # that lowers free space).
+    # One-shot flag so the low-storage warning toast fires exactly once
+    # across the server's lifetime — first browser to connect to the
+    # dashboard sees it; subsequent reloads / tabs do not. Reset to
+    # False if you want it to re-fire (e.g. after a config change that
+    # lowers free space).
     storage_warning_shown: bool = False
 
-    # ---- Network (M1 populates) ----
+    # ---- Network (populated at startup) ----
     device_ip: str = "Unknown"
 
-    # ---- UI toggles (M5) ----
+    # ---- UI toggles ----
     # True = status card body hidden, only header + summary shown.
     # Toggled by the chevron button in the status card header.
     status_card_collapsed: bool = False
@@ -118,8 +116,6 @@ class AppState:
     # flag and refreshes the stats card. Process-lifetime (reset by
     # `service monerodui-web restart` since AppState is re-instantiated
     # at server startup) — intentionally doesn't persist across restarts.
-    # (The old version_banner_dismissed flag was removed when the
-    # version banner became a row in the System Status card.)
     update_banner_dismissed: bool = False
 
     # ---- Derived ----

--- a/src/monerodui_web/core/app_state.py
+++ b/src/monerodui_web/core/app_state.py
@@ -1,0 +1,113 @@
+"""Shared mutable application state for the web UI.
+
+All UI components read from the module-level `state` singleton via
+NiceGUI `@ui.refreshable` functions; background tasks (process state
+callbacks, stats poller) write to it. Mutation is plain attribute
+assignment — no observers.
+
+There are no deployment-specific Configuration Variables in this file;
+all values are runtime-derived from config + system probes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+# Imported from the existing libs package (which has zero Kivy deps).
+# Importing the type here keeps `state.last_stats` correctly typed even
+# though M1 never sets it (poll is M2).
+from monerodui.libs import NodeStats  # noqa: F401  (re-exported via type hint)
+
+
+@dataclass
+class AppState:
+    """Singleton holding all UI-observable state.
+
+    Lifecycle of each field:
+      - process_owned / external_node_running / node_state / last_stats /
+        last_poll_time / last_poll_error:
+            written by the stats poller / process_adapter (M2).
+      - binary_version / update_status:
+            written by VersionChecker / UpdateChecker (M4). M1/M2 leave
+            them at defaults (M2 renders banners conditionally).
+      - arch_*, binary_*, storage_*, device_ip:
+            populated once at startup by `main.initialize()` (M1).
+
+    `node_is_running` is a *derived* property: true if EITHER we own the
+    process OR an external monerod is reachable via RPC. Use the two
+    underlying flags to drive UI affordances (e.g. disable Stop when
+    external-only).
+    """
+
+    # ---- Node lifecycle (M2) ----
+    # Did *we* spawn this monerod? Drives whether Stop is enabled.
+    process_owned: bool = False
+    # Is there an RPC-reachable monerod we did NOT spawn? Surfaces as
+    # "Running (external)" in the UI; Stop is disabled in this case
+    # because killing a process we didn't start is out of scope.
+    external_node_running: bool = False
+    # Human-readable state string for status_card State row.
+    node_state: str = "Stopped"
+    # Last completed poll result (or None if never polled / offline).
+    last_stats: Optional[NodeStats] = None
+    # Timestamp (time.time()) of the most recent successful poll —
+    # used for "staleness" display in the UI.
+    last_poll_time: Optional[float] = None
+    # Latest poll error message (or None if last poll succeeded). Shown
+    # in the offline banner so the user can see *why* the node looks
+    # offline (connection refused vs. timeout vs. RPC error).
+    last_poll_error: Optional[str] = None
+    # Generic "last error" (start-failure message etc.) — populated by
+    # process_adapter on failed start/stop.
+    last_error: Optional[str] = None
+
+    # ---- Live service references (M2 populates from main.initialize) ----
+    # Typed as Any to avoid an import cycle; concrete types are
+    # monerodui.libs.ProcessManager, NodeStatsPoller, VersionChecker,
+    # UpdateChecker.
+    process_manager: Optional[Any] = None
+    node_stats_poller: Optional[Any] = None
+    version_checker: Optional[Any] = None
+    update_checker: Optional[Any] = None
+
+    # ---- Binary metadata (M4 writes, M1/M2 leave defaults) ----
+    binary_version: Optional[str] = None
+    update_status: Optional[Any] = None  # UpdateStatus from libs.update_checker
+
+    # ---- Arch / binary readiness (M1 populates) ----
+    arch_supported: bool = False
+    arch_name: str = "Unknown"
+    binary_path: Optional[Path] = None
+    binary_ready: bool = False
+
+    # ---- Storage check (M1 populates) ----
+    storage_path: Optional[str] = None
+    storage_free_gib: float = 0.0
+    storage_ok: bool = False
+    # M4: one-shot flag so the low-storage warning toast fires exactly
+    # once across the server's lifetime — first browser to connect to
+    # the dashboard sees it; subsequent reloads / tabs do not. Reset
+    # to False if you want it to re-fire (e.g. after a config change
+    # that lowers free space).
+    storage_warning_shown: bool = False
+
+    # ---- Network (M1 populates) ----
+    device_ip: str = "Unknown"
+
+    # ---- UI toggles (M5) ----
+    # True = status card body hidden, only header + summary shown.
+    # Toggled by the chevron button in the status card header.
+    status_card_collapsed: bool = False
+
+    # ---- Derived ----
+
+    @property
+    def node_is_running(self) -> bool:
+        """True if a node is responding — owned OR external."""
+        return self.process_owned or self.external_node_running
+
+
+# Module-level singleton — imported as `from monerodui_web.core import state`.
+state: AppState = AppState()

--- a/src/monerodui_web/core/app_state.py
+++ b/src/monerodui_web/core/app_state.py
@@ -100,6 +100,13 @@ class AppState:
     # True = status card body hidden, only header + summary shown.
     # Toggled by the chevron button in the status card header.
     status_card_collapsed: bool = False
+    # User-dismissed banners. Each banner has an "X" button that flips
+    # the corresponding flag and refreshes the stats card. Flags are
+    # process-lifetime (reset by `service monerodui-web restart` since
+    # AppState is re-instantiated at server startup); they intentionally
+    # don't persist across restarts.
+    version_banner_dismissed: bool = False
+    update_banner_dismissed: bool = False
 
     # ---- Derived ----
 

--- a/src/monerodui_web/core/app_state.py
+++ b/src/monerodui_web/core/app_state.py
@@ -48,6 +48,20 @@ class AppState:
     # "Running (external)" in the UI; Stop is disabled in this case
     # because killing a process we didn't start is out of scope.
     external_node_running: bool = False
+    # Is there an external monerod whose RPC is currently unresponsive?
+    # Most common cause: the daemon is busy syncing (catching up after
+    # downtime) and deprioritizes RPC during catch-up — pgrep finds the
+    # process but RPC times out. Surfaces as "Running (syncing)" so the
+    # user can distinguish this transient state from "Stopped".
+    external_node_busy: bool = False
+    # When external_node_busy is True, these are best-effort enriched
+    # values parsed from the latest "Synced X/Y (...estimated Z minutes
+    # left)" line in monerod's log file. Both fields are None when no
+    # sync line is in the recent log tail (or when external_node_busy
+    # itself is False). Used to enrich the "Running (syncing)" label
+    # with an ETA so the user knows roughly how long to wait.
+    sync_blocks_left: Optional[int] = None
+    sync_eta_minutes: Optional[float] = None
     # Human-readable state string for status_card State row.
     node_state: str = "Stopped"
     # Last completed poll result (or None if never polled / offline).
@@ -112,8 +126,15 @@ class AppState:
 
     @property
     def node_is_running(self) -> bool:
-        """True if a node is responding — owned OR external."""
-        return self.process_owned or self.external_node_running
+        """True if a monerod process is alive — owned, external, or busy
+        syncing. Drives the status-card summary line and other "is there
+        a node here at all?" checks. For finer-grained UI affordances
+        (e.g. whether Stop is enabled) read the underlying flags."""
+        return (
+            self.process_owned
+            or self.external_node_running
+            or self.external_node_busy
+        )
 
 
 # Module-level singleton — imported as `from monerodui_web.core import state`.

--- a/src/monerodui_web/core/app_state.py
+++ b/src/monerodui_web/core/app_state.py
@@ -114,12 +114,12 @@ class AppState:
     # True = status card body hidden, only header + summary shown.
     # Toggled by the chevron button in the status card header.
     status_card_collapsed: bool = False
-    # User-dismissed banners. Each banner has an "X" button that flips
-    # the corresponding flag and refreshes the stats card. Flags are
-    # process-lifetime (reset by `service monerodui-web restart` since
-    # AppState is re-instantiated at server startup); they intentionally
-    # don't persist across restarts.
-    version_banner_dismissed: bool = False
+    # User-dismissed update banner. Has an "X" button that flips the
+    # flag and refreshes the stats card. Process-lifetime (reset by
+    # `service monerodui-web restart` since AppState is re-instantiated
+    # at server startup) — intentionally doesn't persist across restarts.
+    # (The old version_banner_dismissed flag was removed when the
+    # version banner became a row in the System Status card.)
     update_banner_dismissed: bool = False
 
     # ---- Derived ----

--- a/src/monerodui_web/core/clipboard.py
+++ b/src/monerodui_web/core/clipboard.py
@@ -1,0 +1,61 @@
+"""Browser clipboard helper.
+
+`navigator.clipboard.writeText()` only works in secure contexts
+(HTTPS or localhost). When the UI is accessed via a LAN IP over
+plain HTTP (e.g. `http://10.0.0.3:8085`), navigator.clipboard is
+undefined and a naive check like `navigator.clipboard && ...` short-
+circuits silently — the JS does nothing, the Python `ui.notify` runs
+anyway, and the user is told the copy succeeded with an empty
+clipboard.
+
+This module wraps the two-tier approach: try navigator.clipboard
+first, fall back to a hidden-textarea + execCommand('copy') (which
+works in any context, modern browsers still support it as a
+deprecated-but-functional API). Caller handles its own user-facing
+notification.
+"""
+
+from __future__ import annotations
+
+import json
+
+from nicegui import ui
+
+
+def copy_text(text: str) -> None:
+    """Copy `text` to the browser clipboard.
+
+    Async fire-and-forget — we don't await the JS, so we can't
+    distinguish success from failure server-side. The fallback path
+    has been reliable in major browsers for many years; in practice
+    a real failure is rare enough that the caller can assume success
+    for notify purposes.
+    """
+    # json.dumps gives a guaranteed-valid JS string literal for any
+    # input, including special characters that Python's `repr()`
+    # might encode in non-JS-compatible ways.
+    text_js = json.dumps(text)
+    js = f"""
+    (async function() {{
+        const text = {text_js};
+        if (navigator.clipboard && window.isSecureContext) {{
+            try {{
+                await navigator.clipboard.writeText(text);
+                return;
+            }} catch (e) {{
+                // fall through to legacy path
+            }}
+        }}
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        ta.style.pointerEvents = 'none';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        try {{ document.execCommand('copy'); }} catch (e) {{}}
+        document.body.removeChild(ta);
+    }})();
+    """
+    ui.run_javascript(js)

--- a/src/monerodui_web/core/config_manager.py
+++ b/src/monerodui_web/core/config_manager.py
@@ -1,0 +1,570 @@
+"""INI config loader/saver shared with the Kivy app.
+
+The on-disk format is `configparser` INI at
+`~/.config/monerodui/monerodui.ini`. The defaults dict and the
+`get_extra_args()` translator are ported verbatim from the Kivy
+`monerodui.main.monerodUIApp` so the two apps produce identical
+monerod command lines from identical config files.
+
+Configuration Variables
+-----------------------
+The only deployment-specific path baked in here is the config file
+location. To redirect for testing or non-standard deployments, change:
+
+    CONFIG_DIR  = Path.home() / ".config" / "monerodui"   # <<USER MUST SET if non-default>>
+    CONFIG_FILE = CONFIG_DIR / "monerodui.ini"            # <<USER MUST SET if non-default>>
+
+The Kivy app uses the same location (see
+`src/monerodui/main.py:131-133`). Changing one side without the other
+breaks shared-config behavior.
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# --- Configuration Variables ----------------------------------------------
+CONFIG_DIR: Path = Path.home() / ".config" / "monerodui"
+CONFIG_FILE: Path = CONFIG_DIR / "monerodui.ini"
+# --------------------------------------------------------------------------
+
+
+class ConfigManager:
+    """Thin wrapper around `configparser.ConfigParser`.
+
+    Differs from the Kivy `ConfigParser` wrapper in that there is no
+    notify-on-change behavior — UI refresh is driven separately by the
+    NiceGUI `@ui.refreshable` mechanism.
+    """
+
+    def __init__(self, config_path: Path = CONFIG_FILE) -> None:
+        self.config_path: Path = config_path
+        # `interpolation=None` matches Kivy's parser (avoids `%` issues
+        # in values like log filenames and access-control-origins).
+        self.config: configparser.ConfigParser = configparser.ConfigParser(
+            interpolation=None
+        )
+
+    # ---- Load / save ----------------------------------------------------
+
+    def load(self) -> None:
+        """Read INI from disk if present, then apply defaults for any
+        missing section/key. Writes back if anything was added."""
+        if self.config_path.exists():
+            try:
+                self.config.read(self.config_path, encoding="utf-8")
+                logger.info(f"Loaded config: {self.config_path}")
+            except (OSError, configparser.Error) as e:
+                logger.error(f"Failed to read config {self.config_path}: {e}")
+
+        dirty = self._apply_defaults()
+        if dirty:
+            self.save()
+            logger.info("Config repaired with default values and saved")
+
+    def save(self) -> None:
+        """Write current config to disk. Creates parent directory."""
+        try:
+            self.config_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.config_path, "w", encoding="utf-8") as fp:
+                self.config.write(fp)
+        except OSError as e:
+            logger.error(f"Failed to save config {self.config_path}: {e}")
+
+    def _apply_defaults(self) -> bool:
+        """Ensure every default section/key exists. Returns True if any
+        value was inserted."""
+        defaults = self.get_all_defaults()
+        dirty = False
+        for section, options in defaults.items():
+            if not self.config.has_section(section):
+                self.config.add_section(section)
+                dirty = True
+            for key, value in options.items():
+                if not self.config.has_option(section, key):
+                    self.config.set(section, key, value)
+                    dirty = True
+        return dirty
+
+    # ---- Typed accessors ------------------------------------------------
+
+    def get(
+        self,
+        section: str,
+        key: str,
+        fallback: Optional[str] = None,
+    ) -> str:
+        try:
+            return self.config.get(section, key, fallback=fallback)
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            return fallback if fallback is not None else ""
+
+    def getint(self, section: str, key: str, fallback: int = 0) -> int:
+        try:
+            return self.config.getint(section, key, fallback=fallback)
+        except (configparser.NoSectionError, configparser.NoOptionError, ValueError):
+            return fallback
+
+    def getboolean(self, section: str, key: str, fallback: bool = False) -> bool:
+        # The INI uses "0"/"1" rather than True/False, so route through
+        # the string getter for portability with the Kivy app's writes.
+        raw = self.get(section, key, fallback="1" if fallback else "0")
+        return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+    def set(self, section: str, key: str, value: str) -> None:
+        if not self.config.has_section(section):
+            self.config.add_section(section)
+        self.config.set(section, key, str(value))
+
+    # ---- Defaults dict (ported verbatim from Kivy main.py) -------------
+
+    def get_all_defaults(self) -> dict[str, dict[str, str]]:
+        """Return the canonical defaults dict.
+
+        Ported verbatim from `monerodui.main.monerodUIApp.build_config`
+        (src/monerodui/main.py:148-263) and merged with the slightly
+        differing `_ensure_config_integrity` dict (lines 571-626). The
+        only divergence between the two Kivy methods is `storage`:
+            build_config:             "min_free_gib": "10.0"
+            _ensure_config_integrity: "min_free_gib": "50.0"
+        We follow `_ensure_config_integrity` because that is the value
+        the Kivy app rewrites on every startup (it overwrites the
+        `build_config` value at on_start).
+        """
+        return {
+            "network": {
+                "network_type": "mainnet",
+                "offline": "0",
+                "no_sync": "0",
+                "public_node": "0",
+                "sync_pruned_blocks": "1",
+                "pad_transactions": "0",
+            },
+            "p2p": {
+                "bind_ip": "0.0.0.0",
+                "bind_port": "18080",
+                "use_ipv6": "0",
+                "external_port": "0",
+                "out_peers": "-1",
+                "in_peers": "-1",
+                "max_connections_per_ip": "1",
+                "hide_my_port": "0",
+                "allow_local_ip": "0",
+                "priority_nodes": "",
+                "exclusive_nodes": "",
+                "seed_nodes": "",
+                "ban_list": "",
+            },
+            "bandwidth": {
+                "limit_rate_up": "8192",
+                "limit_rate_down": "32768",
+            },
+            "rpc": {
+                "bind_ip": "127.0.0.1",
+                "bind_port": "18081",
+                "restricted_bind_ip": "127.0.0.1",
+                "restricted_bind_port": "0",
+                "restricted": "0",
+                "use_ipv6": "0",
+                "login": "",
+                "confirm_external_bind": "0",
+                "access_control_origins": "",
+                "max_connections": "100",
+                "disable_ban": "0",
+            },
+            "rpcssl": {
+                "mode": "autodetect",
+                "private_key": "",
+                "certificate": "",
+                "ca_certificates": "",
+                "allow_any_cert": "0",
+                "allow_chained": "0",
+            },
+            "zmq": {
+                "disabled": "0",
+                "bind_ip": "127.0.0.1",
+                "bind_port": "18082",
+                "pub": "",
+            },
+            "proxy": {
+                "address": "",
+                "allow_dns_leaks": "0",
+                "tx_proxy": "",
+                "anonymous_inbound": "",
+            },
+            "bootstrap": {
+                "address": "",
+                "login": "",
+                "proxy": "",
+            },
+            "blockchain": {
+                "prune": "1",
+                "fast_block_sync": "1",
+                "db_sync_mode": "fast:async:250000000bytes",
+                "db_salvage": "0",
+                "block_sync_size": "0",
+                "keep_alt_blocks": "0",
+                "max_txpool_weight": "648000000",
+            },
+            "dns": {
+                "enforce_checkpoints": "0",
+                "disable_checkpoints": "0",
+                "enable_blocklist": "0",
+                "check_updates": "notify",
+            },
+            "nat": {
+                "igd": "delayed",
+            },
+            "mining": {
+                "address": "",
+                "threads": "0",
+                "bg_enable": "0",
+                "bg_ignore_battery": "0",
+                "bg_idle_threshold": "0",
+                "bg_miner_target": "0",
+            },
+            "logging": {
+                "file": "",
+                "level": "0",
+                "max_file_size": "104850000",
+                "max_files": "50",
+            },
+            "performance": {
+                "max_concurrency": "0",
+                "prep_blocks_threads": "4",
+            },
+            "notify": {
+                "block_enabled": "0",
+                "reorg_enabled": "0",
+            },
+            "advanced": {
+                "config_file": "",
+                "data_dir": "",
+                "non_interactive": "1",
+                "extra_messages_file": "",
+            },
+            "runtime": {
+                "extra_flags": "",
+                "auto_start": "0",
+                "enable_boot": "0",
+            },
+            "storage": {
+                "min_free_gib": "50.0",
+                "preferred_path": "",
+            },
+            "state": {
+                "was_running": "0",
+            },
+        }
+
+    # ---- monerod CLI args translator ------------------------------------
+
+    def get_extra_args(self) -> list[str]:
+        """Translate the loaded config into monerod CLI arguments.
+
+        Ported verbatim from `monerodui.main.monerodUIApp._get_extra_args`
+        (src/monerodui/main.py:894-1165). The only difference is that
+        `self.config` here is a plain `configparser.ConfigParser` rather
+        than Kivy's wrapper. Every section translation and every flag
+        is preserved so the two apps produce identical monerod
+        command lines from the same INI file.
+        """
+        args: list[str] = []
+
+        args.append("--non-interactive")
+
+        # ---- network ----
+        net_type = self.get("network", "network_type")
+        if net_type == "testnet":
+            args.append("--testnet")
+        elif net_type == "stagenet":
+            args.append("--stagenet")
+
+        if self.get("network", "offline") == "1":
+            args.append("--offline")
+        if self.get("network", "no_sync") == "1":
+            args.append("--no-sync")
+        if self.get("network", "public_node") == "1":
+            args.append("--public-node")
+        if self.get("network", "sync_pruned_blocks") == "1":
+            args.append("--sync-pruned-blocks")
+        if self.get("network", "pad_transactions") == "1":
+            args.append("--pad-transactions")
+
+        # ---- p2p ----
+        bind_ip = self.get("p2p", "bind_ip")
+        if bind_ip and bind_ip != "0.0.0.0":
+            args.extend(["--p2p-bind-ip", bind_ip])
+
+        bind_port = self.get("p2p", "bind_port")
+        if bind_port and bind_port != "18080":
+            args.extend(["--p2p-bind-port", bind_port])
+
+        if self.get("p2p", "use_ipv6") == "1":
+            args.append("--p2p-use-ipv6")
+
+        ext_port = self.get("p2p", "external_port")
+        if ext_port and ext_port != "0":
+            args.extend(["--p2p-external-port", ext_port])
+
+        out_peers = self.get("p2p", "out_peers")
+        if out_peers and out_peers != "-1":
+            args.extend(["--out-peers", out_peers])
+
+        in_peers = self.get("p2p", "in_peers")
+        if in_peers and in_peers != "-1":
+            args.extend(["--in-peers", in_peers])
+
+        max_conns = self.get("p2p", "max_connections_per_ip")
+        if max_conns and max_conns != "1":
+            args.extend(["--max-connections-per-ip", max_conns])
+
+        if self.get("p2p", "hide_my_port") == "1":
+            args.append("--hide-my-port")
+        if self.get("p2p", "allow_local_ip") == "1":
+            args.append("--allow-local-ip")
+
+        priority_nodes = self.get("p2p", "priority_nodes")
+        if priority_nodes:
+            for node in priority_nodes.split(","):
+                if node.strip():
+                    args.extend(["--add-priority-node", node.strip()])
+
+        exclusive_nodes = self.get("p2p", "exclusive_nodes")
+        if exclusive_nodes:
+            for node in exclusive_nodes.split(","):
+                if node.strip():
+                    args.extend(["--add-exclusive-node", node.strip()])
+
+        seed_nodes = self.get("p2p", "seed_nodes")
+        if seed_nodes:
+            args.extend(["--seed-node", seed_nodes])
+
+        ban_list = self.get("p2p", "ban_list")
+        if ban_list:
+            args.extend(["--ban-list", ban_list])
+
+        # ---- bandwidth ----
+        limit_up = self.get("bandwidth", "limit_rate_up")
+        if limit_up and limit_up != "8192":
+            args.extend(["--limit-rate-up", limit_up])
+
+        limit_down = self.get("bandwidth", "limit_rate_down")
+        if limit_down and limit_down != "32768":
+            args.extend(["--limit-rate-down", limit_down])
+
+        # ---- rpc ----
+        rpc_bind_ip = self.get("rpc", "bind_ip")
+        if rpc_bind_ip:
+            args.extend(["--rpc-bind-ip", rpc_bind_ip])
+
+        rpc_bind_port = self.get("rpc", "bind_port")
+        if rpc_bind_port:
+            args.extend(["--rpc-bind-port", rpc_bind_port])
+
+        res_bind_ip = self.get("rpc", "restricted_bind_ip")
+        if res_bind_ip and res_bind_ip != "127.0.0.1":
+            args.extend(["--rpc-restricted-bind-ip", res_bind_ip])
+
+        res_bind_port = self.get("rpc", "restricted_bind_port")
+        if res_bind_port and res_bind_port != "0":
+            args.extend(["--rpc-restricted-bind-port", res_bind_port])
+
+        if self.get("rpc", "restricted") == "1":
+            args.append("--restricted-rpc")
+        if self.get("rpc", "use_ipv6") == "1":
+            args.append("--rpc-use-ipv6")
+
+        rpc_login = self.get("rpc", "login")
+        if rpc_login:
+            args.extend(["--rpc-login", rpc_login])
+
+        if self.get("rpc", "confirm_external_bind") == "1":
+            args.append("--confirm-external-bind")
+
+        cors = self.get("rpc", "access_control_origins")
+        if cors:
+            args.extend(["--rpc-access-control-origins", cors])
+
+        if self.get("rpc", "disable_ban") == "1":
+            args.append("--disable-rpc-ban")
+
+        # ---- rpcssl ----
+        ssl_mode = self.get("rpcssl", "mode")
+        if ssl_mode == "enabled":
+            args.extend(["--rpc-ssl", "enabled"])
+        elif ssl_mode == "disabled":
+            args.extend(["--rpc-ssl", "disabled"])
+
+        ssl_key = self.get("rpcssl", "private_key")
+        if ssl_key:
+            args.extend(["--rpc-ssl-private-key", ssl_key])
+
+        ssl_cert = self.get("rpcssl", "certificate")
+        if ssl_cert:
+            args.extend(["--rpc-ssl-certificate", ssl_cert])
+
+        ca_certs = self.get("rpcssl", "ca_certificates")
+        if ca_certs:
+            args.extend(["--rpc-ssl-ca-certificates", ca_certs])
+
+        if self.get("rpcssl", "allow_any_cert") == "1":
+            args.append("--rpc-ssl-allow-any-cert")
+        if self.get("rpcssl", "allow_chained") == "1":
+            args.append("--rpc-ssl-allow-chained")
+
+        # ---- zmq ----
+        if self.get("zmq", "disabled") == "1":
+            args.append("--no-zmq")
+        else:
+            zmq_ip = self.get("zmq", "bind_ip")
+            zmq_port = self.get("zmq", "bind_port")
+            if zmq_ip and zmq_port:
+                args.extend(
+                    ["--zmq-rpc-bind-ip", zmq_ip, "--zmq-rpc-bind-port", zmq_port]
+                )
+
+            zmq_pub = self.get("zmq", "pub")
+            if zmq_pub:
+                args.extend(["--zmq-pub", zmq_pub])
+
+        # ---- proxy ----
+        proxy = self.get("proxy", "address")
+        if proxy:
+            args.extend(["--proxy", proxy])
+
+        if self.get("proxy", "allow_dns_leaks") == "1":
+            args.append("--allow-dns-leaks")
+
+        tx_proxy = self.get("proxy", "tx_proxy")
+        if tx_proxy:
+            args.extend(["--tx-proxy", tx_proxy])
+
+        anon_inbound = self.get("proxy", "anonymous_inbound")
+        if anon_inbound:
+            args.extend(["--anonymous-inbound", anon_inbound])
+
+        # ---- bootstrap ----
+        boot_addr = self.get("bootstrap", "address")
+        if boot_addr:
+            args.extend(["--bootstrap-daemon-address", boot_addr])
+
+        boot_login = self.get("bootstrap", "login")
+        if boot_login:
+            args.extend(["--bootstrap-daemon-login", boot_login])
+
+        boot_proxy = self.get("bootstrap", "proxy")
+        if boot_proxy:
+            args.extend(["--bootstrap-daemon-proxy", boot_proxy])
+
+        # ---- blockchain ----
+        if self.get("blockchain", "prune") == "1":
+            args.append("--prune-blockchain")
+
+        db_sync = self.get("blockchain", "db_sync_mode")
+        if db_sync:
+            args.extend(["--db-sync-mode", db_sync])
+
+        if self.get("blockchain", "db_salvage") == "1":
+            args.append("--db-salvage")
+
+        if self.get("blockchain", "fast_block_sync") == "1":
+            args.append("--fast-block-sync=1")
+        else:
+            args.append("--fast-block-sync=0")
+
+        if self.get("blockchain", "keep_alt_blocks") == "1":
+            args.append("--keep-alt-blocks")
+
+        max_txpool_weight = self.get("blockchain", "max_txpool_weight")
+        if max_txpool_weight and max_txpool_weight != "648000000":
+            args.extend(["--max-txpool-weight", max_txpool_weight])
+
+        # ---- dns ----
+        if self.get("dns", "enforce_checkpoints") == "1":
+            args.append("--enforce-dns-checkpoints")
+        if self.get("dns", "disable_checkpoints") == "1":
+            args.append("--disable-dns-checkpoints")
+        if self.get("dns", "enable_blocklist") == "1":
+            args.append("--enable-dns-blocklist")
+
+        check_updates = self.get("dns", "check_updates")
+        if check_updates:
+            args.extend(["--check-updates", check_updates])
+
+        # ---- nat ----
+        igd = self.get("nat", "igd")
+        if igd:
+            args.extend(["--igd", igd])
+
+        # ---- mining ----
+        mine_addr = self.get("mining", "address")
+        mine_threads = self.get("mining", "threads")
+        if mine_addr and mine_threads and mine_threads != "0":
+            args.extend(
+                ["--start-mining", mine_addr, "--mining-threads", mine_threads]
+            )
+
+        if self.get("mining", "bg_enable") == "1":
+            args.append("--bg-mining-enable")
+        if self.get("mining", "bg_ignore_battery") == "1":
+            args.append("--bg-mining-ignore-battery")
+
+        bg_threshold = self.get("mining", "bg_idle_threshold")
+        if bg_threshold and bg_threshold != "0":
+            args.extend(["--bg-mining-miner-target", bg_threshold])
+
+        bg_target = self.get("mining", "bg_miner_target")
+        if bg_target and bg_target != "0":
+            args.extend(["--bg-mining-miner-target", bg_target])
+
+        # ---- logging ----
+        log_level = self.get("logging", "level")
+        if log_level:
+            args.extend(["--log-level", log_level])
+
+        max_log_size = self.get("logging", "max_file_size")
+        if max_log_size and max_log_size != "104850000":
+            args.extend(["--max-log-file-size", max_log_size])
+
+        max_logs = self.get("logging", "max_files")
+        if max_logs and max_logs != "50":
+            args.extend(["--max-log-files", max_logs])
+
+        # ---- performance ----
+        prep_threads = self.get("performance", "prep_blocks_threads")
+        if prep_threads and prep_threads != "4":
+            args.extend(["--prep-blocks-threads", prep_threads])
+
+        max_concurrency = self.get("performance", "max_concurrency")
+        if max_concurrency and max_concurrency != "0":
+            args.extend(["--max-concurrency", max_concurrency])
+
+        # ---- advanced ----
+        config_file = self.get("advanced", "config_file")
+        if config_file:
+            args.extend(["--config-file", config_file])
+
+        data_dir = self.get("advanced", "data_dir")
+        if data_dir:
+            args.extend(["--data-dir", data_dir])
+
+        extra_messages = self.get("advanced", "extra_messages_file")
+        if extra_messages:
+            args.extend(["--extra-messages-file", extra_messages])
+
+        # ---- runtime extras ----
+        extra_flags = self.get("runtime", "extra_flags")
+        if extra_flags:
+            args.extend(extra_flags.split())
+
+        return args
+
+
+# Module-level singleton — imported as `from monerodui_web.core import config`.
+config: ConfigManager = ConfigManager()

--- a/src/monerodui_web/core/monero_release.py
+++ b/src/monerodui_web/core/monero_release.py
@@ -1,0 +1,36 @@
+"""Small helpers around Monero releases (download URL construction).
+
+Lives in `core/` so both `main.py` (for the JSON API) and the UI
+components (`node_stats_card.py`'s update banner) can share one
+source of truth for the URL pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def construct_download_url(arch: str, version: str) -> Optional[str]:
+    """Build the canonical downloads.getmonero.org URL for this arch +
+    version.
+
+    Matches the URL monerod itself logs when an update is available
+    (bitmonero.log lines like "Version X.Y.Z of monero for linux-x64
+    is available: https://downloads.getmonero.org/...").
+
+    `arch` values come from `ArchDetector.detected_arch` — see
+    `src/monerodui/libs/arch_detector.py` ARCH_MAP. Returns None for
+    unrecognized arch (caller can hide the URL row / field).
+    """
+    platform_map = {
+        "amd64": "linux-x64",
+        "arm64": "linux-armv8",
+        "arm32": "linux-armv7",
+    }
+    platform = platform_map.get(arch)
+    if platform is None:
+        return None
+    return (
+        f"https://downloads.getmonero.org/cli/"
+        f"monero-{platform}-v{version}.tar.bz2"
+    )

--- a/src/monerodui_web/core/process_adapter.py
+++ b/src/monerodui_web/core/process_adapter.py
@@ -1,6 +1,6 @@
 """External-monerod detection helpers.
 
-Historically (M2 first draft) this file held a `ScreenedMonerod` class
+Historically this file held a `ScreenedMonerod` class
 that wrapped `monerodui.libs.ProcessManager` to launch monerod inside
 `screen -dmS monerod`. That was dropped per user decision: ProcessManager
 already auto-appends `--log-file <data_dir>/monerod.log` (see

--- a/src/monerodui_web/core/process_adapter.py
+++ b/src/monerodui_web/core/process_adapter.py
@@ -1,0 +1,61 @@
+"""External-monerod detection helpers.
+
+Historically (M2 first draft) this file held a `ScreenedMonerod` class
+that wrapped `monerodui.libs.ProcessManager` to launch monerod inside
+`screen -dmS monerod`. That was dropped per user decision: ProcessManager
+already auto-appends `--log-file <data_dir>/monerod.log` (see
+`monerodui/libs/process_manager.py:186-189`), which gives the user the
+same observability `screen -r` would (`tail -f
+/root/.bitmonero/monerod.log`). Dropping the wrapper eliminates pid
+discovery, screen-session-collision handling, and ~250 lines of code.
+
+What's left here is only the *external*-monerod detection helper used
+by the dashboard's polling loop and the startup probe. It does NOT
+manage any process — it just checks whether *any* monerod is running
+on the system regardless of who launched it.
+
+Filename retained as `process_adapter.py` for import-path stability
+(callers still do `from monerodui_web.core.process_adapter import
+discover_external_monerod_pid`).
+
+No deployment-specific Configuration Variables in this file.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def discover_external_monerod_pid() -> Optional[int]:
+    """Return any running `monerod` pid, or None.
+
+    Used in two places:
+
+      1. Startup probe (`main._initial_state_probe_and_autostart`) —
+         cheap pgrep to short-circuit auto-start when an external
+         daemon is already running.
+      2. Per-tick reconciler (`dashboard._apply_poll_result`) —
+         distinguishes "RPC responding because we spawned it" from
+         "RPC responding because someone else's monerod is up".
+
+    Uses `pgrep -x monerod` (basename match, not full-command). This
+    deliberately matches *any* monerod regardless of binary path, since
+    the goal is to detect daemons we did not spawn (which by definition
+    can have any launch path).
+    """
+    try:
+        out = subprocess.run(
+            ["pgrep", "-x", "monerod"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except Exception as e:
+        logger.debug(f"pgrep failed: {e}")
+        return None
+    pids = [int(p) for p in out.stdout.split() if p.strip().isdigit()]
+    return pids[0] if pids else None

--- a/src/monerodui_web/main.py
+++ b/src/monerodui_web/main.py
@@ -478,6 +478,14 @@ def api_status() -> Dict[str, Any]:
         "state": state.node_state,
         "process_owned": state.process_owned,
         "external_node_running": state.external_node_running,
+        # external_node_busy: pgrep finds monerod but RPC times out —
+        # usually means the daemon is busy syncing. When True, the
+        # `sync_blocks_left` and `sync_eta_minutes` fields below are
+        # best-effort parses from monerod's log (may be None if not
+        # available); otherwise both are None.
+        "external_node_busy": state.external_node_busy,
+        "sync_blocks_left": state.sync_blocks_left,
+        "sync_eta_minutes": state.sync_eta_minutes,
         "node_is_running": state.node_is_running,
     }
 

--- a/src/monerodui_web/main.py
+++ b/src/monerodui_web/main.py
@@ -188,7 +188,7 @@ def initialize() -> None:
     # 4. Storage check — port of _check_storage() from src/monerodui/main.py:769-787.
     _check_storage_for_state()
 
-    # 5. Wire live service references onto AppState (M2).
+    # 5. Wire live service references onto AppState.
     _wire_services()
 
     # 6. External-detection probe + auto-start.
@@ -349,7 +349,7 @@ def _check_storage_for_state() -> None:
         state.storage_ok = False
 
 
-# ---- M4: background version + update checks -----------------------------
+# ---- Background version + update checks ---------------------------------
 
 
 async def _kick_off_version_and_update_checks() -> None:
@@ -371,7 +371,7 @@ async def _kick_off_version_and_update_checks() -> None:
     return an empty UpdateStatus with `error="Local version unavailable"`.
     """
     if state.version_checker is None or state.update_checker is None:
-        logger.warning("version/update checkers not wired; skipping M4 checks")
+        logger.warning("version/update checkers not wired; skipping checks")
         return
     if not state.binary_ready or state.binary_path is None:
         logger.info("binary not ready; skipping version+update checks")
@@ -440,7 +440,7 @@ def index() -> None:
 
 @ui.page("/settings")
 def settings_route(focus: str = "") -> None:
-    """Render the full settings page (~70-field parity, M3).
+    """Render the full settings page.
 
     Optional `?focus=<section>.<field>` query param: after the page
     renders, scrolls to the named section and briefly flashes the
@@ -589,7 +589,7 @@ def main() -> None:
     # initialize() runs first (sync): config, arch, binary, storage,
     # services, external probe, auto-start.
     app.on_startup(initialize)
-    # Then the async M4 chain: version + update checks. Registered as a
+    # Then the async chain: version + update checks. Registered as a
     # separate startup hook so it runs *after* initialize() has wired
     # state.version_checker / state.update_checker. NiceGUI awaits each
     # hook in registration order on the asyncio loop.

--- a/src/monerodui_web/main.py
+++ b/src/monerodui_web/main.py
@@ -439,10 +439,16 @@ def index() -> None:
 
 
 @ui.page("/settings")
-def settings_route() -> None:
-    """Render the full settings page (~70-field parity, M3)."""
+def settings_route(focus: str = "") -> None:
+    """Render the full settings page (~70-field parity, M3).
+
+    Optional `?focus=<section>.<field>` query param: after the page
+    renders, scrolls to the named section and briefly flashes the
+    named field. Used by the Storage-row chevron in the status card
+    to land users directly on `advanced.data_dir`.
+    """
     ui.dark_mode().enable()
-    build_settings_page()
+    build_settings_page(focus=focus)
 
 
 # ---- JSON API endpoint ---------------------------------------------------

--- a/src/monerodui_web/main.py
+++ b/src/monerodui_web/main.py
@@ -42,6 +42,7 @@ from monerodui.libs import (
     VersionChecker,
 )
 from monerodui_web.core import config, state
+from monerodui_web.core.monero_release import construct_download_url
 from monerodui_web.core.process_adapter import discover_external_monerod_pid
 from monerodui_web.pages import build_dashboard, build_settings_page
 
@@ -481,12 +482,23 @@ def api_status() -> Dict[str, Any]:
     }
 
     # Update banner block (None when no check has run or no update).
+    # Mirrors the UI banner: includes the SHA256 (`remote_hash`) and the
+    # constructed download URL so script consumers don't have to know
+    # the downloads.getmonero.org URL pattern themselves.
     update_status_block: Any = None
     if state.update_status is not None:
+        remote_version = getattr(state.update_status, "remote_version", None)
+        download_url = (
+            construct_download_url(state.arch_name, remote_version)
+            if remote_version
+            else None
+        )
         update_status_block = {
             "update_available": getattr(state.update_status, "update_available", False),
             "local_version": getattr(state.update_status, "local_version", None),
-            "remote_version": getattr(state.update_status, "remote_version", None),
+            "remote_version": remote_version,
+            "remote_hash": getattr(state.update_status, "remote_hash", None) or None,
+            "download_url": download_url,
         }
 
     # Node stats block (None when poller hasn't returned a result yet).

--- a/src/monerodui_web/main.py
+++ b/src/monerodui_web/main.py
@@ -1,0 +1,582 @@
+"""NiceGUI app entrypoint for monerodui_web.
+
+Run with:
+    python -m monerodui_web          # via __main__.py
+    monerodui-web                    # via console-script (after install)
+
+Configuration Variables
+-----------------------
+The following deployment-specific values are baked in here. Edit
+before deploying to a different host/port:
+
+    WEB_HOST = "0.0.0.0"     # LAN-accessible (per user request 2026-05-26)
+    WEB_PORT = 8085          # <<USER MUST SET if port conflict>>
+
+NOTE: WEB_HOST changed from "127.0.0.1" to "0.0.0.0" on 2026-05-26 at
+user request to allow LAN access from 10.0.0.0/24 clients. There is
+currently NO authentication on the web UI — anyone able to reach
+http://<apollo-ip>:8085 can start/stop monerod and edit its config.
+If untrusted devices may join the LAN, add auth (e.g. nginx basic
+auth in front, or NiceGUI's storage_secret + a login page) before
+relying on this.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict
+
+from nicegui import app, ui
+
+from monerodui.libs import (
+    ArchDetector,
+    NetworkInfo,
+    NodeStatsPoller,
+    ProcessManager,
+    UpdateChecker,
+    VersionChecker,
+)
+from monerodui_web.core import config, state
+from monerodui_web.core.process_adapter import discover_external_monerod_pid
+from monerodui_web.pages import build_dashboard, build_settings_page
+
+# --- Configuration Variables ---------------------------------------------
+WEB_HOST: str = "0.0.0.0"
+WEB_PORT: int = 8085
+WEB_TITLE: str = "monerod UI"
+# Highest-priority binary search path. On apollo, /root/monero is a
+# symlink the user maintains pointing at the current desired Monero
+# release (currently v0.18.4.5). On other hosts this typically doesn't
+# exist and the search falls through to ArchDetector + shutil.which.
+PREFERRED_BINARY: Path = Path("/root/monero/monerod")
+# Monero's own default data dir is ~/.bitmonero/. If the INI's
+# advanced.data_dir is empty on startup, we backfill this value so the
+# Kivy ProcessManager's "--data-dir required" check passes without
+# making the user configure anything.
+DEFAULT_DATA_DIR: Path = Path.home() / ".bitmonero"
+# --------------------------------------------------------------------------
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(name)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Inject global CSS to match the Kivy theme: orange #ff6600 primary,
+# dark backgrounds (#000000 card bg, #333333 body), Quasar primary
+# override via CSS custom properties.
+_GLOBAL_CSS = """
+<style>
+  :root {
+    --q-primary: #ff6600;
+    --q-dark: #000000;
+  }
+  body {
+    background-color: #1a1a1a;
+    color: #ffffff;
+  }
+  .nicegui-content {
+    background-color: #1a1a1a;
+  }
+  .q-card {
+    background-color: #000000;
+    color: #ffffff;
+  }
+  .q-btn[color="orange"] {
+    background-color: #ff6600 !important;
+    color: #ffffff !important;
+  }
+</style>
+"""
+
+
+def _resolve_bin_dir() -> Path:
+    """Mirror the Kivy app's `bin_dir` (Briefcase layout).
+
+    The Kivy app uses `Path(__file__).parent / "assets" / "bin"` from
+    inside `src/monerodui/main.py`. We compute the equivalent path
+    relative to the *Kivy* package so a shared binary install works
+    for both apps. If the directory doesn't exist, `ArchDetector` will
+    just fall through to its project-root / app-root searches and
+    finally to our `shutil.which("monerod")` fallback in initialize().
+    """
+    # /root/monerodui/src/monerodui_web/main.py
+    #   .parent           -> .../monerodui_web/
+    #   .parent.parent    -> .../src/
+    #   / "monerodui" / "assets" / "bin"
+    return Path(__file__).parent.parent / "monerodui" / "assets" / "bin"
+
+
+def initialize() -> None:
+    """Run once at server startup (via `app.on_startup`).
+
+    Order:
+      1. Load config (creates default INI if missing).
+      2. Arch detection + binary resolution (Kivy search + `which` fallback).
+      3. Device IP probe.
+      4. Storage check on configured data_dir.
+    """
+    logger.info("=== monerodui_web INITIALIZATION ===")
+
+    # 1. Config
+    config.load()
+
+    # Backfill empty data_dir with Monero's own default (~/.bitmonero).
+    # The Kivy ProcessManager requires --data-dir to be passed; without
+    # this the user would have to configure it before the first Start.
+    existing_data_dir = config.get("advanced", "data_dir", fallback="")
+    if not existing_data_dir:
+        config.set("advanced", "data_dir", str(DEFAULT_DATA_DIR))
+        config.save()
+        logger.info(f"Backfilled advanced.data_dir = {DEFAULT_DATA_DIR}")
+
+    # 2. Arch detection (always — we want state.arch_name even if the
+    # binary is resolved outside ArchDetector below).
+    bin_dir = _resolve_bin_dir()
+    logger.info(f"Using bin_dir: {bin_dir} (exists={bin_dir.exists()})")
+    try:
+        detector = ArchDetector(bin_dir=bin_dir)
+        state.arch_name = detector.detected_arch or detector.raw_arch or "Unknown"
+        state.arch_supported = detector.is_supported()
+        kivy_binary_path = detector.binary_path
+        kivy_binary_ready = detector.is_ready()
+    except Exception as e:
+        logger.error(f"ArchDetector failed: {e}", exc_info=True)
+        state.arch_name = "Unknown"
+        state.arch_supported = False
+        kivy_binary_path = None
+        kivy_binary_ready = False
+
+    # Binary resolution priority (per user decision 2026-05-26):
+    #   1. PREFERRED_BINARY (/root/monero/monerod — apollo's symlink)
+    #   2. Kivy ArchDetector search (Briefcase layout, project root, app root)
+    #   3. shutil.which("monerod") on PATH
+    if PREFERRED_BINARY.exists() and os.access(PREFERRED_BINARY, os.X_OK):
+        state.binary_path = PREFERRED_BINARY
+        state.binary_ready = True
+        logger.info(f"Resolved monerod via PREFERRED_BINARY: {PREFERRED_BINARY}")
+    elif kivy_binary_path is not None:
+        state.binary_path = kivy_binary_path
+        state.binary_ready = kivy_binary_ready
+        logger.info(f"Resolved monerod via ArchDetector: {kivy_binary_path}")
+    else:
+        which_result = shutil.which("monerod")
+        if which_result:
+            which_path = Path(which_result)
+            state.binary_path = which_path
+            state.binary_ready = which_path.exists() and os.access(which_path, os.X_OK)
+            logger.info(f"Resolved monerod via PATH: {which_path}")
+        else:
+            state.binary_path = None
+            state.binary_ready = False
+            logger.warning(
+                f"monerod binary not found at {PREFERRED_BINARY}, "
+                f"in bin_dir {bin_dir}, or on PATH"
+            )
+
+    # 3. Device IP
+    try:
+        ip = NetworkInfo().get_device_ip()
+        state.device_ip = ip if ip else "No Ext Net"
+    except Exception as e:
+        logger.error(f"NetworkInfo failed: {e}", exc_info=True)
+        state.device_ip = "Unknown"
+
+    # 4. Storage check — port of _check_storage() from src/monerodui/main.py:769-787.
+    _check_storage_for_state()
+
+    # 5. Wire live service references onto AppState (M2).
+    _wire_services()
+
+    # 6. External-detection probe + auto-start.
+    # Port of _complete_initialization (src/monerodui/main.py:677-766).
+    _initial_state_probe_and_autostart()
+
+    logger.info(
+        f"Init done — arch={state.arch_name} supported={state.arch_supported} "
+        f"binary_ready={state.binary_ready} ip={state.device_ip} "
+        f"storage_ok={state.storage_ok} "
+        f"process_owned={state.process_owned} "
+        f"external_node_running={state.external_node_running}"
+    )
+
+
+def _wire_services() -> None:
+    """Instantiate the long-lived service objects and put them on state.
+
+    These live for the server's lifetime. The dashboard page reads them
+    via `state.process_manager` / `state.node_stats_poller` etc.
+    """
+    # RPC poller — host/port come from config (defaults 127.0.0.1:18081).
+    rpc_host = config.get("rpc", "bind_ip", fallback="127.0.0.1")
+    try:
+        rpc_port = int(config.get("rpc", "bind_port", fallback="18081"))
+    except ValueError:
+        rpc_port = 18081
+    # Poller binds to 127.0.0.1 even if monerod is bound to 0.0.0.0 — RPC
+    # access from the same host always works on loopback. Override only
+    # if the configured bind_ip is a specific non-0.0.0.0 address.
+    poll_host = "127.0.0.1" if rpc_host in ("0.0.0.0", "", "127.0.0.1") else rpc_host
+
+    state.node_stats_poller = NodeStatsPoller(host=poll_host, port=rpc_port)
+    state.process_manager = ProcessManager()
+    state.version_checker = VersionChecker()
+    # UpdateChecker takes (version_checker, is_android, arch). Server is
+    # never android; arch falls back to 'amd64' if detection failed.
+    arch = state.arch_name if state.arch_supported else "amd64"
+    state.update_checker = UpdateChecker(
+        state.version_checker,
+        is_android=False,
+        arch=arch,
+    )
+    logger.info(
+        f"Wired services: poller=http://{poll_host}:{rpc_port} "
+        f"process_manager=ProcessManager arch={arch}"
+    )
+
+
+def _initial_state_probe_and_autostart() -> None:
+    """One-shot startup: detect external monerod, optionally auto-start.
+
+    Port of `_complete_initialization` (src/monerodui/main.py:677-766)
+    minus the Android-only boot-preference and was_running paths.
+
+    Decision order:
+      1. If `pgrep -x monerod` finds a daemon AND its RPC responds ->
+         mark external_node_running, skip auto-start.
+      2. Else if runtime.auto_start = 1 AND prerequisites pass ->
+         configure + start via ProcessManager (direct subprocess; monerod's
+         own `--log-file` writes to data_dir/monerod.log, which the user
+         can `tail -f` for the same observability `screen -r` would give).
+      3. Else leave state stopped.
+    """
+    # Probe for external monerod via pgrep (cheap) + RPC poll.
+    ext_pid = discover_external_monerod_pid()
+    if ext_pid is not None:
+        logger.info(f"External monerod pid {ext_pid} detected via pgrep")
+        try:
+            stats = state.node_stats_poller.poll()
+            if stats.status != "offline":
+                state.external_node_running = True
+                state.process_owned = False
+                state.node_state = "Running (external)"
+                state.last_stats = stats
+                import time as _t
+                state.last_poll_time = _t.time()
+                logger.info("External monerod is RPC-responsive; skipping auto-start")
+                return
+            else:
+                logger.info(
+                    f"pgrep found monerod {ext_pid} but RPC unreachable — "
+                    f"treating as not-running for UI purposes"
+                )
+        except Exception as e:
+            logger.warning(f"Initial RPC probe failed: {e}")
+
+    # Auto-start path (desktop equivalent of main.py:736-762).
+    auto_start_raw = config.get("runtime", "auto_start", fallback="0")
+    auto_start = auto_start_raw in ("1", "True", "true")
+    if not auto_start:
+        logger.info("auto_start disabled in config; node remains stopped")
+        return
+
+    if not state.binary_ready or state.binary_path is None:
+        logger.warning("auto_start requested but binary not ready; skipping")
+        return
+
+    data_dir = config.get("advanced", "data_dir", fallback="")
+    if not data_dir:
+        logger.warning("auto_start requested but data_dir not set; skipping")
+        return
+
+    logger.info("Auto-start: configuring ProcessManager and launching")
+    try:
+        extra_args = config.get_extra_args()
+        # Import here to avoid a top-level cycle with dashboard.py.
+        from monerodui_web.pages.dashboard import _on_process_state_change
+        state.process_manager.configure(
+            binary_path=state.binary_path,
+            working_dir=Path(data_dir),
+            extra_args=extra_args,
+            on_state_change=_on_process_state_change,
+        )
+        ok = state.process_manager.start()
+        if ok:
+            state.process_owned = True
+            state.node_state = "Running"
+            logger.info("Auto-start succeeded")
+        else:
+            err = state.process_manager.last_error
+            logger.error(f"Auto-start failed: {err}")
+    except Exception as e:
+        logger.error(f"Auto-start raised: {e}", exc_info=True)
+
+
+def _check_storage_for_state() -> None:
+    """Populate `state.storage_*` from config + os.statvfs.
+
+    Ported from `monerodui.main.monerodUIApp._check_storage`
+    (src/monerodui/main.py:769-787). The Kivy version returns bool and
+    opens a dialog on failure; we just record the result.
+    """
+    data_dir = config.get("advanced", "data_dir")
+    if not data_dir or not Path(data_dir).exists():
+        state.storage_path = data_dir or None
+        state.storage_free_gib = 0.0
+        state.storage_ok = False
+        return
+
+    try:
+        stat = os.statvfs(data_dir)
+        free_gib = (stat.f_bavail * stat.f_frsize) / (1024 ** 3)
+        try:
+            min_free_gib = float(
+                config.get("storage", "min_free_gib", fallback="10.0")
+            )
+        except ValueError:
+            min_free_gib = 10.0
+
+        state.storage_path = data_dir
+        state.storage_free_gib = free_gib
+        state.storage_ok = free_gib >= min_free_gib
+    except OSError as e:
+        logger.error(f"statvfs failed for {data_dir}: {e}")
+        state.storage_path = data_dir
+        state.storage_free_gib = 0.0
+        state.storage_ok = False
+
+
+# ---- M4: background version + update checks -----------------------------
+
+
+async def _kick_off_version_and_update_checks() -> None:
+    """Fire-and-forget chain: version check, then update check.
+
+    Runs once at startup as an asyncio task scheduled by `app.on_startup`.
+    Both checks are sync I/O (subprocess for version, urllib HTTPS for
+    update), so each goes through `run_in_executor` to avoid blocking
+    NiceGUI's event loop. Each task writes its result onto AppState; the
+    next stats-poll tick triggers the per-tab refresh that picks up the
+    new state (so no cross-thread NiceGUI calls are needed here — same
+    pattern as ProcessManager's `on_state_change` callback: mutate
+    state on the worker, let the polling tick on the asyncio loop
+    handle the UI refresh).
+
+    Sequencing matters: UpdateChecker.check() reads
+    `version_checker.cached_version.version` (libs/update_checker.py:53),
+    so the version check MUST complete first or the update check will
+    return an empty UpdateStatus with `error="Local version unavailable"`.
+    """
+    if state.version_checker is None or state.update_checker is None:
+        logger.warning("version/update checkers not wired; skipping M4 checks")
+        return
+    if not state.binary_ready or state.binary_path is None:
+        logger.info("binary not ready; skipping version+update checks")
+        return
+
+    loop = asyncio.get_event_loop()
+
+    # ---- Version check ----
+    # VersionChecker.get_version() takes no path arg; binary_path must be
+    # set on the instance first (libs/version_checker.py:51-53).
+    state.version_checker.set_binary_path(state.binary_path)
+    try:
+        binary_version = await loop.run_in_executor(
+            None, state.version_checker.get_version
+        )
+    except Exception as e:
+        logger.error(f"version check raised: {e}", exc_info=True)
+        binary_version = None
+
+    if binary_version is not None and binary_version.version:
+        state.binary_version = binary_version.display_string
+        logger.info(f"version check ok: {state.binary_version}")
+    else:
+        logger.warning("version check returned no version string")
+
+    # ---- Update check ----
+    # Depends on cached_version being populated above. Even if the
+    # version check failed, attempt the update check — UpdateStatus
+    # will just carry a populated `error` field that the banner
+    # condition (update_available) will treat as no-update.
+    try:
+        update_status = await loop.run_in_executor(
+            None, state.update_checker.check
+        )
+    except Exception as e:
+        logger.error(f"update check raised: {e}", exc_info=True)
+        update_status = None
+
+    if update_status is not None:
+        state.update_status = update_status
+        if update_status.update_available:
+            logger.info(
+                f"update available: {update_status.local_version} -> "
+                f"{update_status.remote_version}"
+            )
+        elif update_status.error:
+            logger.warning(f"update check error: {update_status.error}")
+        else:
+            logger.info(
+                f"up to date: {update_status.local_version} "
+                f">= {update_status.remote_version}"
+            )
+
+
+# ---- NiceGUI page route -------------------------------------------------
+
+ui.add_head_html(_GLOBAL_CSS, shared=True)
+
+
+@ui.page("/")
+def index() -> None:
+    """Render the dashboard for each browser connection."""
+    ui.dark_mode().enable()
+    build_dashboard()
+
+
+@ui.page("/settings")
+def settings_route() -> None:
+    """Render the full settings page (~70-field parity, M3)."""
+    ui.dark_mode().enable()
+    build_settings_page()
+
+
+# ---- JSON API endpoint ---------------------------------------------------
+# NiceGUI exposes the underlying FastAPI `app`, so we can register a plain
+# REST route alongside the @ui.page UI routes. This mirrors the dashboard's
+# visible data as machine-readable JSON for scripts / monitoring.
+#
+# GET /api/status — returns everything the dashboard shows. Same security
+# posture as the UI (no auth; reachable from anything on 10.0.0.0/24).
+
+
+@app.get("/api/status")
+def api_status() -> Dict[str, Any]:
+    """JSON mirror of the dashboard. Snapshot at request time.
+
+    Updated server-side every POLL_INTERVAL_SECS by the dashboard's
+    polling tick; clients see whatever was in `state` when the GET landed.
+    """
+    # Config-derived flag — authoritative, no heuristic.
+    restricted_rpc = config.getboolean("rpc", "restricted", fallback=False)
+
+    # System status block (everything in the status card).
+    system_status: Dict[str, Any] = {
+        "architecture": state.arch_name,
+        "architecture_supported": state.arch_supported,
+        "device_ip": state.device_ip,
+        "binary_path": str(state.binary_path) if state.binary_path else None,
+        "binary_ready": state.binary_ready,
+        "binary_version": state.binary_version,
+        "storage_path": state.storage_path,
+        "storage_free_gib": round(state.storage_free_gib, 3),
+        "storage_ok": state.storage_ok,
+        "state": state.node_state,
+        "process_owned": state.process_owned,
+        "external_node_running": state.external_node_running,
+        "node_is_running": state.node_is_running,
+    }
+
+    # Update banner block (None when no check has run or no update).
+    update_status_block: Any = None
+    if state.update_status is not None:
+        update_status_block = {
+            "update_available": getattr(state.update_status, "update_available", False),
+            "local_version": getattr(state.update_status, "local_version", None),
+            "remote_version": getattr(state.update_status, "remote_version", None),
+        }
+
+    # Node stats block (None when poller hasn't returned a result yet).
+    node_stats_block: Any = None
+    if state.last_stats is not None:
+        s = state.last_stats
+        # asdict() gives a flat dict of all NodeStats fields; we shape
+        # it into the same sections the UI uses for clarity.
+        target_h = getattr(s, "target_height", 0) or 0
+        progress = (
+            (s.height / target_h) if (target_h > 0 and s.height <= target_h)
+            else 1.0 if s.synchronized
+            else 0.0
+        )
+        node_stats_block = {
+            "nettype": s.nettype,
+            "sync": {
+                "synchronized": s.synchronized,
+                "height": s.height,
+                "target_height": target_h,
+                "progress_fraction": round(progress, 6),
+                "busy_syncing": s.busy_syncing,
+            },
+            "overview": {
+                "connections_total": s.incoming_connections + s.outgoing_connections,
+                "connections_incoming": s.incoming_connections,
+                "connections_outgoing": s.outgoing_connections,
+                "block_height": s.height,
+                "free_space_gib": round(state.storage_free_gib, 3),
+            },
+            "network": {
+                "hashrate": s.hashrate,
+                "difficulty": s.difficulty,
+                "peerlist_white": s.white_peerlist_size,
+                "peerlist_grey": s.grey_peerlist_size,
+                "peerlist_total": s.white_peerlist_size + s.grey_peerlist_size,
+            },
+            "blockchain": {
+                "tx_count": s.tx_count,
+                "tx_pool_size": s.tx_pool_size,
+                "block_reward_atomic": s.block_reward,
+                "fee_estimate_atomic": s.fee_estimate,
+                "database_size_bytes": s.database_size,
+            },
+            "resources": {
+                "bytes_in_mib": round(s.bytes_in_mib, 3),
+                "bytes_out_mib": round(s.bytes_out_mib, 3),
+            },
+            # True if monerod is running with --restricted-rpc. When True,
+            # several fields above will be 0 (connections, peerlists,
+            # bandwidth) because monerod redacts them at the RPC layer —
+            # NOT because the values are actually zero.
+            "restricted_rpc": restricted_rpc,
+            "status": s.status,
+        }
+
+    return {
+        "system_status": system_status,
+        "update_status": update_status_block,
+        "node_stats": node_stats_block,
+        "polling": {
+            "last_poll_time": state.last_poll_time,
+            "last_poll_error": state.last_poll_error,
+            "poll_interval_secs": 10,
+        },
+    }
+
+
+# ---- Console-script entry ------------------------------------------------
+
+
+def main() -> None:
+    """Console-script entry. Registers startup hook and runs the server."""
+    # initialize() runs first (sync): config, arch, binary, storage,
+    # services, external probe, auto-start.
+    app.on_startup(initialize)
+    # Then the async M4 chain: version + update checks. Registered as a
+    # separate startup hook so it runs *after* initialize() has wired
+    # state.version_checker / state.update_checker. NiceGUI awaits each
+    # hook in registration order on the asyncio loop.
+    app.on_startup(_kick_off_version_and_update_checks)
+    ui.run(
+        host=WEB_HOST,
+        port=WEB_PORT,
+        title=WEB_TITLE,
+        dark=True,
+        reload=False,
+        show=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/monerodui_web/pages/__init__.py
+++ b/src/monerodui_web/pages/__init__.py
@@ -1,0 +1,6 @@
+"""NiceGUI page builders for monerodui_web."""
+
+from .dashboard import build_dashboard
+from .settings import build_settings_page
+
+__all__ = ["build_dashboard", "build_settings_page"]

--- a/src/monerodui_web/pages/dashboard.py
+++ b/src/monerodui_web/pages/dashboard.py
@@ -54,7 +54,7 @@ FIRST_POLL_DELAY_SECS: float = 1.0
 
 def build_dashboard() -> None:
     """Build the dashboard UI inside the active NiceGUI page context."""
-    # M4: low-storage warning toast. Fires once across the server's
+    # Low-storage warning toast. Fires once across the server's
     # lifetime (state.storage_warning_shown is the latch). We deliver
     # it from here rather than from main.initialize() because ui.notify
     # is only valid inside a NiceGUI client context — calling it from

--- a/src/monerodui_web/pages/dashboard.py
+++ b/src/monerodui_web/pages/dashboard.py
@@ -1,0 +1,390 @@
+"""Dashboard page (`/`) — the main view.
+
+Layout (top to bottom):
+  - Header row: title + gear icon (gear navigates to `/settings`).
+  - Scrollable body: status card + node-stats card.
+  - Page-level footnote explaining the `*` markers in the node-stats
+    card (Connections / Known Peers / Bandwidth are redacted under
+    monerod's `--restricted-rpc` mode).
+  - Footer: Start / Stop button (tri-state — owned / external / stopped).
+
+Polling:
+  - A NiceGUI `ui.timer(POLL_INTERVAL_SECS, _poll_stats_tick)` runs per
+    browser connection. The first tick fires after 1 s (matching the
+    Kivy `Clock.schedule_once(poll, 1)` from main.py:1205), subsequent
+    ticks every 10 s.
+  - The poll itself runs in a thread executor because
+    `NodeStatsPoller.poll()` is synchronous and may block up to 30 s.
+  - On each tick we ALSO check whether the daemon we (might have)
+    spawned is still alive — see external-detection logic in
+    `_apply_poll_result()`.
+
+Configuration Variables
+-----------------------
+    POLL_INTERVAL_SECS   = 10   # matches Kivy main.py:1206
+    FIRST_POLL_DELAY_SECS = 1   # matches Kivy main.py:1205
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import time
+from typing import Optional
+
+from nicegui import ui
+
+from monerodui_web.components import build_node_stats_card, build_status_card
+from monerodui_web.core import config, state
+from monerodui_web.core.process_adapter import discover_external_monerod_pid
+from monerodui.libs import NodeStats
+from monerodui.libs.process_manager import ProcessState
+
+logger = logging.getLogger(__name__)
+
+
+# --- Configuration Variables ---------------------------------------------
+POLL_INTERVAL_SECS: int = 10
+FIRST_POLL_DELAY_SECS: float = 1.0
+# --------------------------------------------------------------------------
+
+
+def build_dashboard() -> None:
+    """Build the dashboard UI inside the active NiceGUI page context."""
+    # M4: low-storage warning toast. Fires once across the server's
+    # lifetime (state.storage_warning_shown is the latch). We deliver
+    # it from here rather than from main.initialize() because ui.notify
+    # is only valid inside a NiceGUI client context — calling it from
+    # an `app.on_startup` hook is a no-op (no connected client to push
+    # to).
+    if not state.storage_ok and not state.storage_warning_shown:
+        try:
+            min_free_gib = float(
+                config.get("storage", "min_free_gib", fallback="10.0")
+            )
+        except ValueError:
+            min_free_gib = 10.0
+        path = state.storage_path or "(not configured)"
+        ui.notify(
+            f"Low storage: {path} has {state.storage_free_gib:.1f} GiB "
+            f"free, below {min_free_gib:.0f} GiB threshold.",
+            type="warning",
+            timeout=10000,
+        )
+        state.storage_warning_shown = True
+
+    # Page-level full-height column with dark body bg.
+    with ui.column().classes("w-full").style(
+        "max-width: 900px; margin: 0 auto; padding: 16px; gap: 16px;"
+    ):
+        # ---- Header ----
+        with ui.row().classes("items-center w-full no-wrap").style("gap: 8px;"):
+            ui.label("monerod UI").style(
+                "color: #ff6600; font-size: 24px; font-weight: 700;"
+            )
+            ui.space()
+            ui.button(
+                icon="settings",
+                on_click=lambda: ui.navigate.to("/settings"),
+            ).props("flat round color=white").tooltip("Settings")
+
+        # ---- Scrollable body ----
+        with ui.scroll_area().classes("w-full").style(
+            "height: calc(100vh - 240px);"
+        ):
+            with ui.column().classes("w-full").style("gap: 16px;"):
+                build_status_card()
+                build_node_stats_card()
+
+        # ---- Restricted-RPC footnote (page-level, always shown) ----
+        # Sits outside the cards so the explanation for any "*" markers
+        # in the Node Statistics card is visible regardless of scroll
+        # position. Subtle dim italic; negative margin-top pulls it up
+        # against the bottom of the cards (the parent column has
+        # gap: 16px between children, which we counteract here so the
+        # footnote visually attaches to the box above it).
+        ui.label(
+            "* Connections, Known Peers, and Bandwidth are redacted by "
+            "monerod's --restricted-rpc mode. The daemon still has that "
+            "data; it just intentionally doesn't share it over RPC."
+        ).style(
+            "color: #999999; font-size: 10px; font-style: italic; "
+            "text-align: center; padding: 0 16px; margin-top: -12px;"
+        )
+
+        # ---- Footer: Start / Stop button (tri-state) ----
+        with ui.row().classes("items-center w-full justify-center").style(
+            "padding-top: 8px;"
+        ):
+            build_start_stop_button()
+
+    # ---- Polling timer ----
+    # First poll immediately (1s delay, matches Kivy main.py:1205) so
+    # the user doesn't stare at "node not running" for 10 s.
+    ui.timer(FIRST_POLL_DELAY_SECS, _poll_stats_tick, once=True)
+    ui.timer(POLL_INTERVAL_SECS, _poll_stats_tick)
+
+
+# ---- Start / Stop button -------------------------------------------------
+
+
+@ui.refreshable
+def build_start_stop_button() -> None:
+    """Tri-state Start/Stop. Refresh after state changes."""
+    if state.process_owned:
+        ui.button(
+            "Stop",
+            icon="stop_circle",
+            on_click=_on_stop_click,
+        ).props("color=orange unelevated")
+    elif state.external_node_running:
+        # Cannot stop a process we didn't start.
+        btn = ui.button(
+            "Stop (external)",
+            icon="stop_circle",
+        ).props("color=grey unelevated")
+        btn.disable()
+        btn.tooltip(
+            "monerod was not spawned by monerodui — stop it from "
+            "wherever it was launched (e.g. `screen -r monerod` then "
+            "Ctrl-C if you started it that way, or `kill <pid>`)."
+        )
+    else:
+        # Stopped — show Start. Disabled if prerequisites missing.
+        can_start = (
+            state.binary_ready
+            and state.binary_path is not None
+            and state.storage_path is not None
+            and state.process_manager is not None
+        )
+        btn = ui.button(
+            "Start",
+            icon="play_circle",
+            on_click=_on_start_click if can_start else None,
+        ).props("color=orange unelevated")
+        if not can_start:
+            btn.disable()
+            reason = "Cannot start: "
+            if not state.binary_ready:
+                reason += "binary not ready. "
+            elif not state.storage_path:
+                reason += "data dir not configured. "
+            elif state.process_manager is None:
+                reason += "process manager not initialized. "
+            btn.tooltip(reason.strip())
+
+
+async def _on_start_click() -> None:
+    """Configure + start monerod via ProcessManager."""
+    pm = state.process_manager
+    if pm is None:
+        ui.notify("Process manager not initialized", type="negative")
+        return
+    if state.binary_path is None:
+        ui.notify("monerod binary not resolved", type="negative")
+        return
+
+    data_dir = config.get("advanced", "data_dir", fallback="")
+    if not data_dir:
+        ui.notify("data_dir is not configured", type="negative")
+        return
+
+    # Pre-check: refuse to start if the RPC port is already bound. This
+    # prevents the silent-crash UX where monerod spawns, fails to bind
+    # RPC within ~1s, and the UI just blips back to Stopped with an
+    # opaque last_poll_error. Common case: user's external monerod is
+    # already holding the port.
+    rpc_ip = config.get("rpc", "bind_ip", fallback="127.0.0.1")
+    try:
+        rpc_port = int(config.get("rpc", "bind_port", fallback="18081"))
+    except ValueError:
+        rpc_port = 18081
+    if _port_in_use(rpc_ip, rpc_port):
+        ui.notify(
+            f"Port {rpc_ip}:{rpc_port} is already in use — "
+            f"stop the existing daemon first (e.g. `screen -r monerod` "
+            f"+ Ctrl-C, or `kill <pid>`).",
+            type="negative",
+            timeout=10000,
+        )
+        return
+
+    ui.notify("Starting monerod...", type="info")
+
+    def _do_start() -> bool:
+        try:
+            extra_args = config.get_extra_args()
+            from pathlib import Path as _P
+            pm.configure(
+                binary_path=state.binary_path,
+                working_dir=_P(data_dir),
+                extra_args=extra_args,
+                on_state_change=_on_process_state_change,
+            )
+            return pm.start()
+        except Exception as e:
+            logger.error(f"start failed: {e}", exc_info=True)
+            state.last_error = str(e)
+            return False
+
+    loop = asyncio.get_event_loop()
+    ok = await loop.run_in_executor(None, _do_start)
+
+    if ok:
+        # ProcessManager._monitor() thread will fire _on_process_state_change
+        # when the daemon exits, flipping process_owned back to False.
+        state.process_owned = True
+        state.node_state = "Running"
+        ui.notify("monerod started", type="positive")
+    else:
+        err = pm.last_error or state.last_error or "unknown"
+        ui.notify(f"Start failed: {err}", type="negative")
+
+    build_start_stop_button.refresh()
+    build_status_card.refresh()
+    # Trigger an immediate poll so stats appear ASAP.
+    await _poll_stats_tick()
+
+
+async def _on_stop_click() -> None:
+    pm = state.process_manager
+    if pm is None:
+        ui.notify("Process manager not initialized", type="negative")
+        return
+    if not state.process_owned:
+        ui.notify("Cannot stop a process we didn't start", type="warning")
+        return
+
+    ui.notify("Stopping monerod...", type="info")
+    loop = asyncio.get_event_loop()
+    ok = await loop.run_in_executor(None, pm.stop)
+    if ok:
+        state.process_owned = False
+        state.node_state = "Stopped"
+        state.last_stats = None
+        ui.notify("monerod stopped", type="positive")
+    else:
+        err = pm.last_error or "unknown"
+        ui.notify(f"Stop failed: {err}", type="negative")
+
+    build_start_stop_button.refresh()
+    build_status_card.refresh()
+    build_node_stats_card.refresh()
+
+
+def _on_process_state_change(ps: ProcessState) -> None:
+    """Adapter callback. Runs in the watcher thread — no UI calls here.
+
+    We just mutate AppState; the next polling tick (on the asyncio loop)
+    will pick up the change and call .refresh() on the components. This
+    avoids cross-thread NiceGUI calls — refreshable components can only
+    be safely refreshed from the asyncio loop, not from arbitrary
+    background threads spawned by ProcessManager.
+    """
+    logger.info(f"process state change: {ps.name}")
+    if ps == ProcessState.RUNNING:
+        state.process_owned = True
+        state.node_state = "Running"
+    elif ps in (ProcessState.STOPPED, ProcessState.ERROR):
+        state.process_owned = False
+        state.node_state = "Stopped" if ps == ProcessState.STOPPED else "Error"
+
+
+# ---- Port pre-check helper ----------------------------------------------
+
+
+def _port_in_use(host: str, port: int) -> bool:
+    """True if (host, port) is already bound by another process.
+
+    Tries to bind a fresh socket; if it fails the port is taken. For
+    `0.0.0.0` we pass empty string (Linux convention for "all interfaces").
+    """
+    bind_host = "" if host in ("0.0.0.0", "::") else host
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((bind_host, port))
+            return False
+        except OSError:
+            return True
+
+
+# ---- Polling -------------------------------------------------------------
+
+
+async def _poll_stats_tick() -> None:
+    """ui.timer callback. Poll node + reconcile owned/external flags."""
+    poller = state.node_stats_poller
+    if poller is None:
+        # initialize() hasn't finished yet — first-tick can race startup.
+        logger.info("poll tick fired but poller not yet wired")
+        return
+
+    loop = asyncio.get_event_loop()
+    result: Optional[NodeStats] = None
+    err: Optional[str] = None
+    try:
+        result = await loop.run_in_executor(None, poller.poll)
+    except Exception as e:
+        err = str(e)
+        logger.error(f"poll failed: {e}", exc_info=True)
+
+    _apply_poll_result(result, err)
+
+    build_status_card.refresh()
+    build_node_stats_card.refresh()
+    build_start_stop_button.refresh()
+
+
+def _apply_poll_result(result: Optional[NodeStats], err: Optional[str]) -> None:
+    """Reconcile poll result with process_owned / external_node_running.
+
+    Truth table:
+      poll succeeded (status != offline)  AND we own a live pid    -> owned
+      poll succeeded                      AND we DON'T own a pid   -> external
+      poll failed/offline                 AND we own a live pid    -> owned but RPC down (rare)
+      poll failed/offline                 AND we DON'T own a pid   -> stopped
+    """
+    now = time.time()
+    pm = state.process_manager
+
+    rpc_reachable = (
+        result is not None and result.status != "offline"
+    )
+    we_have_live_pid = bool(pm is not None and pm.is_running)
+
+    if rpc_reachable:
+        state.last_stats = result
+        state.last_poll_time = now
+        state.last_poll_error = None
+        if we_have_live_pid:
+            state.process_owned = True
+            state.external_node_running = False
+            state.node_state = "Running"
+        else:
+            state.process_owned = False
+            state.external_node_running = True
+            state.node_state = "Running (external)"
+    else:
+        # No RPC. If we still own a pid, the daemon may be alive but
+        # not yet accepting RPC (startup) — keep state but stash error.
+        state.last_poll_error = err or (
+            result.status if result is not None else "no response"
+        )
+        if we_have_live_pid:
+            state.process_owned = True
+            state.external_node_running = False
+            # Keep node_state "Running" so the UI doesn't flicker.
+            # last_stats is stale but the offline banner only triggers
+            # when last_stats is None — so leave it.
+        else:
+            state.process_owned = False
+            # Even with no RPC, pgrep might still find an external
+            # monerod that hasn't bound its RPC port. We treat that as
+            # not-externally-running for UI purposes (no RPC = nothing
+            # we can display) but keep the field consistent.
+            ext_pid = discover_external_monerod_pid()
+            state.external_node_running = ext_pid is not None and rpc_reachable
+            if not state.external_node_running:
+                state.last_stats = None
+                state.node_state = "Stopped"

--- a/src/monerodui_web/pages/dashboard.py
+++ b/src/monerodui_web/pages/dashboard.py
@@ -29,8 +29,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import socket
 import time
+from pathlib import Path
 from typing import Optional
 
 from nicegui import ui
@@ -132,6 +134,14 @@ def build_dashboard() -> None:
 @ui.refreshable
 def build_start_stop_button() -> None:
     """Tri-state Start/Stop. Refresh after state changes."""
+    # Hide the button entirely when an external monerod is syncing —
+    # nothing the user can do here (Stop is a no-op on processes we
+    # didn't spawn, Start would just collide with the live daemon).
+    # The status card already shows "Running (syncing — ~Xm)" so the
+    # state is visible without a useless greyed-out button.
+    if state.external_node_busy and not state.process_owned:
+        return
+
     if state.process_owned:
         ui.button(
             "Stop",
@@ -139,7 +149,8 @@ def build_start_stop_button() -> None:
             on_click=_on_stop_click,
         ).props("color=orange unelevated")
     elif state.external_node_running:
-        # Cannot stop a process we didn't start.
+        # External monerod with responsive RPC — show greyed-out Stop
+        # with a tooltip explaining why it's disabled.
         btn = ui.button(
             "Stop (external)",
             icon="stop_circle",
@@ -291,6 +302,45 @@ def _on_process_state_change(ps: ProcessState) -> None:
         state.node_state = "Stopped" if ps == ProcessState.STOPPED else "Error"
 
 
+# ---- monerod log sync-progress parser -----------------------------------
+
+# Matches lines like:
+#   Synced 3683092/3683298 (99%, 206 left, 16% of total synced, estimated 28.0 minutes left)
+# monerod writes one of these to bitmonero.log every ~2-3 min during catch-up.
+_SYNC_LINE_RE = re.compile(
+    r"Synced (\d+)/(\d+)\s+\(\d+%,\s+(\d+) left,.+estimated\s+([\d.]+)\s+minutes left"
+)
+
+
+def _parse_latest_sync_progress(log_path: Path) -> Optional[dict]:
+    """Tail the last ~64 KB of monerod's log and return the most recent
+    sync-progress info (blocks remaining + ETA minutes). Returns None if
+    the log is unreadable or contains no sync line in the tail window.
+
+    Used only when external_node_busy is True (i.e. RPC is unresponsive
+    and we need an alternate source for sync status). Cheap — bounded
+    read + regex over a small window.
+    """
+    try:
+        with open(log_path, "rb") as f:
+            f.seek(0, 2)  # end
+            size = f.tell()
+            offset = max(0, size - 65536)
+            f.seek(offset)
+            tail = f.read().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+
+    matches = list(_SYNC_LINE_RE.finditer(tail))
+    if not matches:
+        return None
+    m = matches[-1]
+    return {
+        "blocks_left": int(m.group(3)),
+        "eta_minutes": float(m.group(4)),
+    }
+
+
 # ---- Port pre-check helper ----------------------------------------------
 
 
@@ -357,6 +407,12 @@ def _apply_poll_result(result: Optional[NodeStats], err: Optional[str]) -> None:
         state.last_stats = result
         state.last_poll_time = now
         state.last_poll_error = None
+        # Any RPC success clears the busy/syncing flag and its enriched
+        # fields — the daemon is responding, no longer "alive but
+        # unresponsive".
+        state.external_node_busy = False
+        state.sync_blocks_left = None
+        state.sync_eta_minutes = None
         if we_have_live_pid:
             state.process_owned = True
             state.external_node_running = False
@@ -374,17 +430,45 @@ def _apply_poll_result(result: Optional[NodeStats], err: Optional[str]) -> None:
         if we_have_live_pid:
             state.process_owned = True
             state.external_node_running = False
+            state.external_node_busy = False
+            state.sync_blocks_left = None
+            state.sync_eta_minutes = None
             # Keep node_state "Running" so the UI doesn't flicker.
             # last_stats is stale but the offline banner only triggers
             # when last_stats is None — so leave it.
         else:
             state.process_owned = False
-            # Even with no RPC, pgrep might still find an external
-            # monerod that hasn't bound its RPC port. We treat that as
-            # not-externally-running for UI purposes (no RPC = nothing
-            # we can display) but keep the field consistent.
+            state.external_node_running = False
+            # No owned process AND no RPC. Use pgrep to disambiguate:
+            #   - pgrep finds monerod → daemon is alive but RPC is
+            #     unresponsive (almost always "busy syncing after a
+            #     downtime"; monerod deprioritizes RPC during catch-up).
+            #     Surface as "Running (syncing)" so the user knows
+            #     it's transient, not a real outage.
+            #   - pgrep finds nothing → truly stopped.
             ext_pid = discover_external_monerod_pid()
-            state.external_node_running = ext_pid is not None and rpc_reachable
-            if not state.external_node_running:
+            if ext_pid is not None:
+                state.external_node_busy = True
+                state.node_state = "Running (syncing)"
+                # Best-effort: parse the latest sync line from
+                # monerod's log to enrich the label with an ETA. RPC
+                # is unresponsive during sync, so the log is the only
+                # path to this info while we're in the busy state.
+                data_dir = config.get("advanced", "data_dir", fallback="")
+                info = None
+                if data_dir:
+                    info = _parse_latest_sync_progress(
+                        Path(data_dir) / "bitmonero.log"
+                    )
+                if info is not None:
+                    state.sync_blocks_left = info["blocks_left"]
+                    state.sync_eta_minutes = info["eta_minutes"]
+                else:
+                    state.sync_blocks_left = None
+                    state.sync_eta_minutes = None
+            else:
+                state.external_node_busy = False
+                state.sync_blocks_left = None
+                state.sync_eta_minutes = None
                 state.last_stats = None
                 state.node_state = "Stopped"

--- a/src/monerodui_web/pages/settings.py
+++ b/src/monerodui_web/pages/settings.py
@@ -1,0 +1,673 @@
+"""Settings page (`/settings`) — full parity with the Kivy
+`MDApp.open_settings()` panel.
+
+SETTINGS_SCHEMA mirrors `src/monerodui/settings/settings_schema.json`
+field-for-field: 17 group separators + 82 editable fields across 17 INI
+sections (verified 2026-05-27). The schema is duplicated here as Python
+data — not loaded from JSON at runtime — so this file is self-contained
+and the structure is greppable in source.
+
+Layout:
+  - Header row: Back button + title + Save button.
+  - Section accordion (`ui.expansion`): commonly-edited sections
+    (Network, P2P, RPC, Blockchain, Advanced) are open by default; the
+    other 15 are collapsed but one click away.
+  - Floating Save button at the bottom for long pages.
+
+Save handler reads each rendered widget's current value, coerces to the
+INI-friendly string format (`"0"`/`"1"` for booleans, str-of-number for
+numerics), and writes via `config.set()` + `config.save()`. The Kivy
+app reads the same file with identical key/section names, so a "Save"
+here is immediately visible there too.
+
+Data Directory picker:
+  - The `advanced.data_dir` field gets a special inline row: a text
+    input plus a "folder_open" icon button. The button opens a
+    `ui.dialog()` with: a typeable path input, a "../" parent button,
+    and a list of subdirectories (read via `os.scandir`). Clicking a
+    subdirectory navigates into it; "Select this directory" writes the
+    path back to the main input.
+
+Configuration Variables
+-----------------------
+    EXPANDED_BY_DEFAULT: sections rendered open in the accordion.
+    INI_KEYS_WITHOUT_CLI_CONSUMER: documented fields that don't map to
+        a monerod CLI flag in `get_extra_args()` but are read elsewhere
+        (Android-only, runtime/state/storage bookkeeping, or future-use).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from nicegui import ui
+
+from monerodui_web.core import config
+
+logger = logging.getLogger(__name__)
+
+
+# --- Configuration Variables --------------------------------------------------
+
+# Sections rendered open by default — the ones a user is most likely to
+# touch. Everything else starts collapsed (clearly labelled, one click).
+EXPANDED_BY_DEFAULT: set[str] = {"network", "p2p", "rpc", "blockchain", "advanced"}
+
+# Fields whose INI key is intentionally NOT translated to a CLI flag by
+# config.get_extra_args(). They are still rendered so that:
+#   - the INI stays compatible with the Kivy app's reader
+#   - future versions may wire them up
+#   - the user can still see/edit their stored values
+# Each entry: (section, key) -> reason
+INI_KEYS_WITHOUT_CLI_CONSUMER: dict[tuple[str, str], str] = {
+    ("runtime", "auto_start"): "consumed by web startup logic (main.py)",
+    ("runtime", "enable_boot"): "Android-only (boot receiver); no-op on web",
+    ("notify", "block_enabled"): "Android-only (notifications); no-op on web",
+    ("notify", "reorg_enabled"): "Android-only (notifications); no-op on web",
+    ("advanced", "non_interactive"): "implicit — --non-interactive is always passed",
+    ("blockchain", "block_sync_size"): (
+        "schema-defined but no CLI flag emitted by get_extra_args() "
+        "(Kivy's translator omits it too); stored for future use"
+    ),
+    ("rpc", "max_connections"): (
+        "schema-defined but Kivy's _get_extra_args() does not emit "
+        "--rpc-max-connections; stored for future use"
+    ),
+    ("logging", "file"): (
+        "schema-defined but Kivy's _get_extra_args() does not emit "
+        "--log-file (ProcessManager auto-appends --log-file pointing at "
+        "data_dir/monerod.log); stored for future use"
+    ),
+}
+
+# -----------------------------------------------------------------------------
+
+
+# Field-for-field mirror of src/monerodui/settings/settings_schema.json.
+# Restructured from the flat JSON (with "title" group separators) into a
+# nested list-of-sections keyed by the INI section name. This keeps the
+# save loop trivial and lets us drive the accordion directly.
+SETTINGS_SCHEMA: list[dict[str, Any]] = [
+    {
+        "section_key": "runtime",
+        "title": "Launcher",
+        "fields": [
+            {"key": "extra_flags", "title": "Extra Flags", "type": "string",
+             "desc": "Additional raw command-line flags (advanced)"},
+            {"key": "auto_start", "title": "Auto Start", "type": "bool",
+             "desc": "Automatically start daemon when app launches"},
+            {"key": "enable_boot", "title": "Start on Boot", "type": "bool",
+             "desc": "Android only — start node when device restarts"},
+        ],
+    },
+    {
+        "section_key": "notify",
+        "title": "Notifications (Android)",
+        "fields": [
+            {"key": "block_enabled", "title": "Block Notifications", "type": "bool",
+             "desc": "Android only — notification on new block"},
+            {"key": "reorg_enabled", "title": "Reorg Notifications", "type": "bool",
+             "desc": "Android only — notification on chain reorganization"},
+        ],
+    },
+    {
+        "section_key": "proxy",
+        "title": "Proxy / Tor",
+        "fields": [
+            {"key": "address", "title": "Proxy", "type": "string",
+             "desc": "SOCKS proxy for network traffic (ip:port, e.g. 127.0.0.1:9050)"},
+            {"key": "allow_dns_leaks", "title": "Allow DNS Leaks", "type": "bool",
+             "desc": "Allow DNS queries outside of proxy"},
+            {"key": "tx_proxy", "title": "TX Proxy", "type": "string",
+             "desc": "Proxy for local txs: tor,ip:port[,max_conn][,disable_noise]"},
+            {"key": "anonymous_inbound", "title": "Anonymous Inbound", "type": "string",
+             "desc": "Hidden service: address,bind:port[,max_conn]"},
+        ],
+    },
+    {
+        "section_key": "network",
+        "title": "Network",
+        "fields": [
+            {"key": "network_type", "title": "Network Type", "type": "options",
+             "options": ["mainnet", "testnet", "stagenet"],
+             "desc": "Select which network to connect to"},
+            {"key": "offline", "title": "Offline Mode", "type": "bool",
+             "desc": "Do not listen for peers, nor connect to any"},
+            {"key": "no_sync", "title": "No Sync", "type": "bool",
+             "desc": "Don't synchronize the blockchain with other peers"},
+            {"key": "public_node", "title": "Public Node", "type": "bool",
+             "desc": "Allow others to use this node as a remote (restricted RPC, view-only)"},
+            {"key": "sync_pruned_blocks", "title": "Sync Pruned Blocks", "type": "bool",
+             "desc": "Allow syncing from nodes with only pruned blocks"},
+            {"key": "pad_transactions", "title": "Pad Transactions", "type": "bool",
+             "desc": "Pad relayed transactions to defend against traffic volume analysis"},
+        ],
+    },
+    {
+        "section_key": "blockchain",
+        "title": "Blockchain",
+        "fields": [
+            {"key": "prune", "title": "Prune Blockchain", "type": "bool",
+             "desc": "Enable blockchain pruning to save disk space"},
+            {"key": "db_sync_mode", "title": "DB Sync Mode", "type": "options",
+             "options": ["fast:async:250000000bytes", "safe:sync", "fastest:async"],
+             "desc": "Database sync mode (safe is slower but safer)"},
+            {"key": "db_salvage", "title": "DB Salvage", "type": "bool",
+             "desc": "Try to salvage corrupted blockchain database"},
+            {"key": "block_sync_size", "title": "Block Sync Size", "type": "numeric",
+             "desc": "Blocks to sync at once (0 = adaptive)"},
+            {"key": "fast_block_sync", "title": "Fast Block Sync", "type": "bool",
+             "desc": "Use embedded block hashes for faster sync"},
+            {"key": "keep_alt_blocks", "title": "Keep Alt Blocks", "type": "bool",
+             "desc": "Keep alternative blocks on restart"},
+            {"key": "max_txpool_weight", "title": "Max Txpool Weight (bytes)",
+             "type": "numeric",
+             "desc": "Maximum transaction pool weight (default: 648000000)"},
+        ],
+    },
+    {
+        "section_key": "rpc",
+        "title": "RPC Server",
+        "fields": [
+            {"key": "bind_ip", "title": "RPC Bind IP", "type": "string",
+             "desc": "IP address for RPC server (default: 127.0.0.1)"},
+            {"key": "bind_port", "title": "RPC Bind Port", "type": "numeric",
+             "desc": "Port for RPC server (default: 18081)"},
+            {"key": "restricted_bind_ip", "title": "Restricted RPC Bind IP", "type": "string",
+             "desc": "IP for restricted RPC server"},
+            {"key": "restricted_bind_port", "title": "Restricted RPC Port", "type": "numeric",
+             "desc": "Port for restricted RPC server"},
+            {"key": "restricted", "title": "Restricted RPC", "type": "bool",
+             "desc": "Restrict RPC to view-only commands, hide sensitive data"},
+            {"key": "use_ipv6", "title": "Use IPv6", "type": "bool",
+             "desc": "Allow IPv6 for RPC connections"},
+            {"key": "login", "title": "RPC Login", "type": "string",
+             "desc": "username:password for RPC authentication"},
+            {"key": "confirm_external_bind", "title": "Confirm External Bind", "type": "bool",
+             "desc": "Confirm binding RPC to non-loopback address (required for external access)"},
+            {"key": "access_control_origins", "title": "CORS Origins", "type": "string",
+             "desc": "Comma-separated origins for cross-origin resource sharing"},
+            {"key": "max_connections", "title": "Max Connections", "type": "numeric",
+             "desc": "Maximum total RPC connections permitted (default: 100)"},
+            {"key": "disable_ban", "title": "Disable RPC Ban", "type": "bool",
+             "desc": "Do not ban hosts on RPC errors"},
+        ],
+    },
+    {
+        "section_key": "p2p",
+        "title": "P2P Settings",
+        "fields": [
+            {"key": "bind_ip", "title": "P2P Bind IP (IPv4)", "type": "string",
+             "desc": "Interface for p2p network protocol"},
+            {"key": "bind_port", "title": "P2P Bind Port", "type": "numeric",
+             "desc": "Port for p2p network protocol (default: 18080)"},
+            {"key": "use_ipv6", "title": "Use IPv6", "type": "bool",
+             "desc": "Enable IPv6 for p2p connections"},
+            {"key": "external_port", "title": "External Port", "type": "numeric",
+             "desc": "External port for p2p if using NAT/port forwarding (0 = disabled)"},
+            {"key": "out_peers", "title": "Max Out Peers", "type": "numeric",
+             "desc": "Maximum number of outgoing peer connections (-1 = default)"},
+            {"key": "in_peers", "title": "Max In Peers", "type": "numeric",
+             "desc": "Maximum number of incoming peer connections (-1 = default)"},
+            {"key": "max_connections_per_ip", "title": "Max Connections Per IP",
+             "type": "numeric",
+             "desc": "Maximum p2p connections allowed from same IP address"},
+            {"key": "hide_my_port", "title": "Hide My Port", "type": "bool",
+             "desc": "Do not announce yourself as peerlist candidate"},
+            {"key": "allow_local_ip", "title": "Allow Local IP", "type": "bool",
+             "desc": "Allow local IP addresses in peer list (debug)"},
+            {"key": "priority_nodes", "title": "Add Priority Nodes", "type": "string",
+             "desc": "Peers to connect to and keep open (comma-separated)"},
+            {"key": "exclusive_nodes", "title": "Add Exclusive Nodes", "type": "string",
+             "desc": "Connect ONLY to these peers (comma-separated, overrides other peer options)"},
+            {"key": "seed_nodes", "title": "Seed Nodes", "type": "string",
+             "desc": "Nodes to retrieve peer addresses from (comma-separated)"},
+            {"key": "ban_list", "title": "Ban List File", "type": "string",
+             "desc": "Path to file containing banned IPs (one per line)"},
+        ],
+    },
+    {
+        "section_key": "bandwidth",
+        "title": "Bandwidth Limits",
+        "fields": [
+            {"key": "limit_rate_up", "title": "Upload Limit (kB/s)", "type": "numeric",
+             "desc": "Maximum upload rate in kB/s (default: 8192)"},
+            {"key": "limit_rate_down", "title": "Download Limit (kB/s)", "type": "numeric",
+             "desc": "Maximum download rate in kB/s (default: 32768)"},
+        ],
+    },
+    {
+        "section_key": "rpcssl",
+        "title": "RPC SSL",
+        "fields": [
+            {"key": "mode", "title": "SSL Mode", "type": "options",
+             "options": ["autodetect", "enabled", "disabled"],
+             "desc": "Enable SSL on RPC connections"},
+            {"key": "private_key", "title": "SSL Private Key", "type": "string",
+             "desc": "Path to PEM format private key"},
+            {"key": "certificate", "title": "SSL Certificate", "type": "string",
+             "desc": "Path to PEM format certificate"},
+            {"key": "ca_certificates", "title": "CA Certificates", "type": "string",
+             "desc": "Path to file with CA certificate(s) to replace system CAs"},
+            {"key": "allow_any_cert", "title": "Allow Any Cert", "type": "bool",
+             "desc": "Allow any peer certificate (insecure)"},
+            {"key": "allow_chained", "title": "Allow Chained", "type": "bool",
+             "desc": "Allow user chain certificates"},
+        ],
+    },
+    {
+        "section_key": "zmq",
+        "title": "ZMQ",
+        "fields": [
+            {"key": "disabled", "title": "Disable ZMQ", "type": "bool",
+             "desc": "Disable ZMQ RPC server"},
+            {"key": "bind_ip", "title": "ZMQ Bind IP", "type": "string",
+             "desc": "IP for ZMQ RPC server (default: 127.0.0.1)"},
+            {"key": "bind_port", "title": "ZMQ Bind Port", "type": "numeric",
+             "desc": "Port for ZMQ RPC server (default: 18082)"},
+            {"key": "pub", "title": "ZMQ Pub Address", "type": "string",
+             "desc": "Address for ZMQ pub (tcp://ip:port or ipc://path)"},
+        ],
+    },
+    {
+        "section_key": "bootstrap",
+        "title": "Bootstrap Daemon",
+        "fields": [
+            {"key": "address", "title": "Bootstrap Address", "type": "string",
+             "desc": "URL of bootstrap daemon for wallets while syncing ('auto' for public nodes)"},
+            {"key": "login", "title": "Bootstrap Login", "type": "string",
+             "desc": "username:password for bootstrap daemon"},
+            {"key": "proxy", "title": "Bootstrap Proxy", "type": "string",
+             "desc": "SOCKS proxy for bootstrap connections (ip:port)"},
+        ],
+    },
+    {
+        "section_key": "dns",
+        "title": "DNS & Checkpoints",
+        "fields": [
+            {"key": "enforce_checkpoints", "title": "Enforce DNS Checkpoints", "type": "bool",
+             "desc": "Enforce checkpoints retrieved from DNS"},
+            {"key": "disable_checkpoints", "title": "Disable DNS Checkpoints", "type": "bool",
+             "desc": "Do not retrieve checkpoints from DNS"},
+            {"key": "enable_blocklist", "title": "Enable DNS Blocklist", "type": "bool",
+             "desc": "Apply realtime blocklist from DNS"},
+            {"key": "check_updates", "title": "Check Updates", "type": "options",
+             "options": ["notify", "disabled", "download", "update"],
+             "desc": "How to handle new version notifications"},
+        ],
+    },
+    {
+        "section_key": "nat",
+        "title": "UPnP / NAT",
+        "fields": [
+            {"key": "igd", "title": "UPnP Mode", "type": "options",
+             "options": ["delayed", "enabled", "disabled"],
+             "desc": "UPnP port mapping behavior"},
+        ],
+    },
+    {
+        "section_key": "mining",
+        "title": "Mining",
+        "fields": [
+            {"key": "address", "title": "Mining Address", "type": "string",
+             "desc": "Wallet address to mine to"},
+            {"key": "threads", "title": "Mining Threads", "type": "numeric",
+             "desc": "Number of mining threads"},
+            {"key": "bg_enable", "title": "Background Mining", "type": "bool",
+             "desc": "Enable background mining"},
+            {"key": "bg_ignore_battery", "title": "Ignore Battery", "type": "bool",
+             "desc": "Mine on battery (assume plugged in if status unknown)"},
+            {"key": "bg_idle_threshold", "title": "Idle Threshold (%)", "type": "numeric",
+             "desc": "Minimum idle percentage to start background mining"},
+            {"key": "bg_miner_target", "title": "Miner CPU Target (%)", "type": "numeric",
+             "desc": "Maximum CPU usage for background miner"},
+        ],
+    },
+    {
+        "section_key": "logging",
+        "title": "Logging",
+        "fields": [
+            {"key": "file", "title": "Log File", "type": "string",
+             "desc": "Path to log file (leave empty for default)"},
+            {"key": "level", "title": "Log Level", "type": "options",
+             "options": ["0", "1", "2", "3", "4"],
+             "desc": "Logging verbosity"},
+            {"key": "max_file_size", "title": "Max Log Size (bytes)", "type": "numeric",
+             "desc": "Maximum log file size before rotation (default: 104850000)"},
+            {"key": "max_files", "title": "Max Log Files", "type": "numeric",
+             "desc": "Maximum rotated log files to keep (0 = unlimited)"},
+        ],
+    },
+    {
+        "section_key": "performance",
+        "title": "Performance",
+        "fields": [
+            {"key": "max_concurrency", "title": "Max Concurrency", "type": "numeric",
+             "desc": "Max threads for parallel jobs (0 = auto)"},
+            {"key": "prep_blocks_threads", "title": "Prep Blocks Threads", "type": "numeric",
+             "desc": "Threads for preparing block hashes (default: 4)"},
+        ],
+    },
+    {
+        "section_key": "advanced",
+        "title": "Advanced",
+        "fields": [
+            {"key": "config_file", "title": "Config File", "type": "string",
+             "desc": "Path to external config file"},
+            # data_dir gets special rendering (text input + folder picker).
+            {"key": "data_dir", "title": "Data Directory", "type": "path",
+             "desc": "Custom data directory path"},
+            {"key": "non_interactive", "title": "Non-Interactive", "type": "bool",
+             "desc": "Run in non-interactive mode (always implicitly enabled by the web launcher)"},
+            {"key": "extra_messages_file", "title": "Extra Messages File", "type": "string",
+             "desc": "File with extra messages for coinbase transactions"},
+        ],
+    },
+]
+
+
+# ---- helpers ----------------------------------------------------------------
+
+
+def _coerce_to_str(value: Any, field_type: str) -> str:
+    """Convert a widget value into the INI string representation.
+
+    bools become "0"/"1" to match the Kivy app's format (its
+    `ConfigParser` reads with `getboolean` which accepts both, but
+    Kivy's writer always emits "0"/"1"). Numerics become str(int) when
+    the float is whole, else str(float). Strings pass through unchanged.
+    """
+    if field_type == "bool":
+        return "1" if bool(value) else "0"
+    if field_type == "numeric":
+        if value is None or value == "":
+            return "0"
+        try:
+            f = float(value)
+            if f.is_integer():
+                return str(int(f))
+            return str(f)
+        except (TypeError, ValueError):
+            return str(value)
+    # string / options / path
+    return "" if value is None else str(value)
+
+
+# ---- Data directory picker dialog ------------------------------------------
+
+
+def _open_dir_picker(data_dir_input: ui.input) -> None:
+    """Open a modal dialog with a server-side directory browser.
+
+    The user is on the same machine as the server (localhost-or-LAN),
+    so a typeable path field plus a simple list-based navigator covers
+    the common cases without a full tree widget.
+    """
+    # Anchor the starting path: current value, else $HOME.
+    start_raw = (data_dir_input.value or "").strip()
+    start_path = Path(start_raw) if start_raw else Path.home()
+    # Walk up until we find an existing dir (handles "user typed garbage").
+    while not start_path.exists() and start_path != start_path.parent:
+        start_path = start_path.parent
+    if not start_path.exists():
+        start_path = Path.home()
+
+    # Mutable holder so inner closures can rebind without `nonlocal` games.
+    current: dict[str, Path] = {"path": start_path.resolve()}
+
+    with ui.dialog() as dialog, ui.card().style("min-width: 600px; max-width: 90vw;"):
+        ui.label("Select Data Directory").classes("text-h6")
+
+        path_label = ui.label(f"Current: {current['path']}").style(
+            "font-family: monospace; word-break: break-all;"
+        )
+
+        # Editable path — user can type directly.
+        path_input = ui.input(
+            label="Path",
+            value=str(current["path"]),
+        ).classes("w-full")
+
+        # Subdirectory list container — rebuilt on every navigation.
+        list_container = ui.column().classes("w-full").style(
+            "max-height: 320px; overflow-y: auto; gap: 4px;"
+        )
+
+        def refresh_listing() -> None:
+            list_container.clear()
+            path = current["path"]
+            path_label.set_text(f"Current: {path}")
+            path_input.set_value(str(path))
+
+            with list_container:
+                # Parent navigation row.
+                if path.parent != path:
+                    ui.button(
+                        ".. (parent)",
+                        icon="arrow_upward",
+                        on_click=lambda: navigate_to(path.parent),
+                    ).props("flat align=left").classes("w-full")
+
+                # Subdirectories.
+                try:
+                    entries = sorted(
+                        (e for e in os.scandir(path) if e.is_dir()),
+                        key=lambda e: e.name.lower(),
+                    )
+                except (OSError, PermissionError) as e:
+                    ui.label(f"Cannot list directory: {e}").style("color: #ff6666;")
+                    return
+
+                if not entries:
+                    ui.label("(no subdirectories)").style("color: #888;")
+                    return
+
+                for entry in entries:
+                    sub = Path(entry.path)
+                    ui.button(
+                        entry.name,
+                        icon="folder",
+                        on_click=lambda _e=None, p=sub: navigate_to(p),
+                    ).props("flat align=left").classes("w-full")
+
+        def navigate_to(p: Path) -> None:
+            try:
+                resolved = p.resolve()
+                if resolved.exists() and resolved.is_dir():
+                    current["path"] = resolved
+                    refresh_listing()
+                else:
+                    ui.notify(f"Not a directory: {p}", type="warning")
+            except (OSError, RuntimeError) as e:
+                ui.notify(f"Cannot navigate: {e}", type="warning")
+
+        def go_typed() -> None:
+            """Honor whatever the user typed into the path input."""
+            typed = (path_input.value or "").strip()
+            if typed:
+                navigate_to(Path(typed))
+
+        path_input.on("blur", lambda _e: go_typed())
+        path_input.on("keydown.enter", lambda _e: go_typed())
+
+        def select_current() -> None:
+            data_dir_input.set_value(str(current["path"]))
+            dialog.close()
+
+        with ui.row().classes("w-full justify-end").style("gap: 8px; padding-top: 8px;"):
+            ui.button("Cancel", on_click=dialog.close).props("flat")
+            ui.button(
+                "Select this directory",
+                on_click=select_current,
+                icon="check",
+            ).props("color=orange unelevated")
+
+        refresh_listing()
+
+    dialog.open()
+
+
+# ---- Page builder -----------------------------------------------------------
+
+
+def build_settings_page() -> None:
+    """Render the `/settings` route inside the active NiceGUI page."""
+    # Maps (section_key, field_key) -> widget reference, so the Save
+    # handler can read every current value uniformly.
+    widget_refs: dict[tuple[str, str], Any] = {}
+
+    with ui.column().classes("w-full").style(
+        "max-width: 900px; margin: 0 auto; padding: 16px; gap: 16px;"
+    ):
+        # ---- Header ----
+        with ui.row().classes("items-center w-full no-wrap").style("gap: 8px;"):
+            ui.button(
+                icon="arrow_back",
+                on_click=lambda: ui.navigate.to("/"),
+            ).props("flat round color=white").tooltip("Back to dashboard")
+            ui.label("Settings").style(
+                "color: #ff6600; font-size: 24px; font-weight: 700;"
+            )
+            ui.space()
+            ui.button(
+                "Save",
+                icon="save",
+                on_click=lambda: _on_save(widget_refs),
+            ).props("color=orange unelevated")
+
+        ui.label(
+            f"Config file: {config.config_path}"
+        ).style("color: #888; font-size: 12px; font-family: monospace;")
+
+        # ---- Sections ----
+        for section in SETTINGS_SCHEMA:
+            section_key: str = section["section_key"]
+            title: str = section["title"]
+            fields: list[dict[str, Any]] = section["fields"]
+
+            expanded = section_key in EXPANDED_BY_DEFAULT
+            with ui.expansion(
+                title,
+                icon="settings",
+                value=expanded,
+            ).classes("w-full").props("header-class=text-orange") as exp:
+                # Tighten internal layout.
+                exp.style("background: #1f1f1f; border: 1px solid #333; border-radius: 6px;")
+                with ui.column().classes("w-full").style("padding: 8px 12px; gap: 8px;"):
+                    for field in fields:
+                        _render_field(section_key, field, widget_refs)
+
+        # ---- Floating Save (footer) ----
+        with ui.row().classes("w-full justify-end").style("padding-top: 16px;"):
+            ui.button(
+                "Save",
+                icon="save",
+                on_click=lambda: _on_save(widget_refs),
+            ).props("color=orange unelevated size=lg")
+
+
+def _render_field(
+    section_key: str,
+    field: dict[str, Any],
+    widget_refs: dict[tuple[str, str], Any],
+) -> None:
+    """Render one INI field, wire it into the widget_refs map."""
+    field_type: str = field["type"]
+    field_key: str = field["key"]
+    field_title: str = field["title"]
+    desc: str = field.get("desc", "")
+
+    # Honor existing INI value over schema default. ConfigManager
+    # already backfills defaults at load(), so `config.get(...)`
+    # should never return empty for keys defined in get_all_defaults.
+    raw_value = config.get(section_key, field_key, fallback="")
+
+    annotation = ""
+    if (section_key, field_key) in INI_KEYS_WITHOUT_CLI_CONSUMER:
+        annotation = f"  ({INI_KEYS_WITHOUT_CLI_CONSUMER[(section_key, field_key)]})"
+
+    if field_type == "bool":
+        # Accept "1"/"true"/"yes"/"on" as truthy (Kivy's writer uses "0"/"1").
+        current_bool = str(raw_value).strip().lower() in ("1", "true", "yes", "on")
+        widget = ui.switch(text=field_title, value=current_bool)
+        widget_refs[(section_key, field_key)] = widget
+        if desc or annotation:
+            ui.label(f"{desc}{annotation}").style("color: #888; font-size: 12px;")
+
+    elif field_type == "numeric":
+        try:
+            current_num: float = float(raw_value) if raw_value not in ("", None) else 0.0
+        except (TypeError, ValueError):
+            current_num = 0.0
+        widget = ui.number(label=field_title, value=current_num).classes("w-full")
+        widget_refs[(section_key, field_key)] = widget
+        if desc or annotation:
+            ui.label(f"{desc}{annotation}").style("color: #888; font-size: 12px;")
+
+    elif field_type == "options":
+        options: list[str] = field.get("options", [])
+        current_val = str(raw_value) if raw_value else (options[0] if options else "")
+        if current_val not in options and options:
+            current_val = options[0]
+        widget = ui.select(
+            options=options,
+            label=field_title,
+            value=current_val,
+        ).classes("w-full")
+        widget_refs[(section_key, field_key)] = widget
+        if desc or annotation:
+            ui.label(f"{desc}{annotation}").style("color: #888; font-size: 12px;")
+
+    elif field_type == "path":
+        # Text input + Browse button, side by side.
+        with ui.row().classes("items-end w-full no-wrap").style("gap: 8px;"):
+            widget = ui.input(label=field_title, value=str(raw_value or "")).classes(
+                "flex-grow"
+            )
+            ui.button(
+                icon="folder_open",
+                on_click=lambda _e=None, w=widget: _open_dir_picker(w),
+            ).props("flat round color=orange").tooltip("Browse directories")
+        widget_refs[(section_key, field_key)] = widget
+        if desc or annotation:
+            ui.label(f"{desc}{annotation}").style("color: #888; font-size: 12px;")
+
+    else:  # "string" or anything unrecognized — default to text input
+        widget = ui.input(label=field_title, value=str(raw_value or "")).classes("w-full")
+        widget_refs[(section_key, field_key)] = widget
+        if desc or annotation:
+            ui.label(f"{desc}{annotation}").style("color: #888; font-size: 12px;")
+
+
+def _on_save(widget_refs: dict[tuple[str, str], Any]) -> None:
+    """Write every rendered field's current value into the INI."""
+    written = 0
+    try:
+        for section in SETTINGS_SCHEMA:
+            section_key: str = section["section_key"]
+            for field in section["fields"]:
+                field_key: str = field["key"]
+                field_type: str = field["type"]
+                widget = widget_refs.get((section_key, field_key))
+                if widget is None:
+                    continue
+                value = widget.value
+                config.set(
+                    section_key,
+                    field_key,
+                    _coerce_to_str(value, field_type),
+                )
+                written += 1
+        config.save()
+        logger.info(f"Settings saved: {written} fields written to {config.config_path}")
+        ui.notify(
+            f"Saved {written} settings. Restart monerod for them to take effect.",
+            type="positive",
+            timeout=5000,
+        )
+    except Exception as e:
+        logger.error(f"Save failed: {e}", exc_info=True)
+        ui.notify(f"Save failed: {e}", type="negative", timeout=8000)

--- a/src/monerodui_web/pages/settings.py
+++ b/src/monerodui_web/pages/settings.py
@@ -513,11 +513,39 @@ def _open_dir_picker(data_dir_input: ui.input) -> None:
 # ---- Page builder -----------------------------------------------------------
 
 
-def build_settings_page() -> None:
-    """Render the `/settings` route inside the active NiceGUI page."""
+def build_settings_page(focus: str = "") -> None:
+    """Render the `/settings` route inside the active NiceGUI page.
+
+    `focus` (optional): "<section>.<field>" — after render, scroll to
+    that section, force-expand it if needed, and briefly flash the
+    field input. Passed in from the `/settings` route via query param.
+    """
     # Maps (section_key, field_key) -> widget reference, so the Save
     # handler can read every current value uniformly.
     widget_refs: dict[tuple[str, str], Any] = {}
+
+    # Inject the CSS for the field-flash animation once per page load.
+    # Uses orange (#ff6600) to match the rest of the theme.
+    ui.add_head_html(
+        """
+<style>
+@keyframes monerodui-flash-kf {
+  0%   { background-color: rgba(255, 102, 0, 0.45); }
+  100% { background-color: transparent; }
+}
+.monerodui-flash {
+  animation: monerodui-flash-kf 2s ease-out;
+  border-radius: 6px;
+}
+</style>
+"""
+    )
+
+    # Parse focus: must be "<section>.<field>" for both halves to apply.
+    focus_section: str = ""
+    focus_field: str = ""
+    if "." in focus:
+        focus_section, focus_field = focus.split(".", 1)
 
     with ui.column().classes("w-full").style(
         "max-width: 900px; margin: 0 auto; padding: 16px; gap: 16px;"
@@ -548,12 +576,20 @@ def build_settings_page() -> None:
             title: str = section["title"]
             fields: list[dict[str, Any]] = section["fields"]
 
-            expanded = section_key in EXPANDED_BY_DEFAULT
+            # If this is the focused section, force-expand it even if
+            # it's normally collapsed (e.g. "advanced" is expanded by
+            # default, but other targets may not be).
+            expanded = (
+                section_key in EXPANDED_BY_DEFAULT
+                or section_key == focus_section
+            )
             with ui.expansion(
                 title,
                 icon="settings",
                 value=expanded,
-            ).classes("w-full").props("header-class=text-orange") as exp:
+            ).classes("w-full").props(
+                f"header-class=text-orange id=monerodui-section-{section_key}"
+            ) as exp:
                 # Tighten internal layout.
                 exp.style("background: #1f1f1f; border: 1px solid #333; border-radius: 6px;")
                 with ui.column().classes("w-full").style("padding: 8px 12px; gap: 8px;"):
@@ -567,6 +603,34 @@ def build_settings_page() -> None:
                 icon="save",
                 on_click=lambda: _on_save(widget_refs),
             ).props("color=orange unelevated size=lg")
+
+    # ---- Post-render: scroll + flash if focus was requested ----
+    if focus_section and focus_field:
+        widget = widget_refs.get((focus_section, focus_field))
+        # Quasar widgets render to <div id="qXXXX">; grab that id and
+        # use it for both the scroll target and the flash class.
+        widget_id = widget.id if widget is not None else ""
+        section_dom_id = f"monerodui-section-{focus_section}"
+        # Run after a short delay so the DOM is settled.
+        ui.timer(
+            0.2,
+            lambda: ui.run_javascript(
+                f"""
+                (function() {{
+                    const section = document.getElementById('{section_dom_id}');
+                    if (section) {{
+                        section.scrollIntoView({{behavior: 'smooth', block: 'start'}});
+                    }}
+                    const field = document.getElementById('c{widget_id}');
+                    if (field) {{
+                        field.classList.add('monerodui-flash');
+                        setTimeout(() => field.classList.remove('monerodui-flash'), 2100);
+                    }}
+                }})();
+                """
+            ),
+            once=True,
+        )
 
 
 def _render_field(


### PR DESCRIPTION
I'm not going to lie, the lion's share of the heavy lifting for this PR was made by Claude AI.  In addition to guiding, directing and leading the feature addition, as well as testing, I also made edits and contributions as well.  But, in full transparency, I did not write 3000 lines of code ...haha.

So, anyway, this PR adds `src/monerodui_web/`:  a parallel browser-based UI built on NiceGUI. Same dashboard layout as the Kivy app, same `monerodui.ini`, same monerod control.  The Kivy app is **untouched** and `monerodui_web` is excluded from the Android build.

This PR also: 
- Includes one bugfix in `UpdateChecker` — its desktop branch was hard-coded to `linux-x64` regardless of actual arch.   I submitted this as a separate PR via https://github.com/PromptPunksFauxCough/monerodui/pull/3
- Includes a url can be used to export all information provided by the UI as json. _(See README.md within the src/monerodui_web subdirectory.)_

---
I won't be offended at all if you don't want to implement this.  Or, maybe if you want to make a separate branch for it and return to it later (or just have it as a separate branch in case someone might ask for it), then that's cool too.  I just thought I'd offer it in case it was useful, since I have found it useful when hosting monerod on a headless linux server.